### PR TITLE
Adding grunt-version to build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    pkg: '<json:package.json>',
+    pkg: grunt.file.readJSON('package.json'),
 
     meta: {
       banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
@@ -46,6 +46,19 @@ module.exports = function(grunt) {
       }
     },
 
+    // "grunt-version": "https://github.com/kswedberg/grunt-version/tarball/master"
+    version: {
+      check: {
+        src: ['package.json']
+      },
+      release: {
+        options: {
+          release: 'patch'
+        },
+        src: ['package.json']
+      }
+    },
+
 
     jshint: {
       files: ['Gruntfile.js', 'lib/**/*.js', 'tasks/**/*.js', 'test/**/*.js'],
@@ -77,6 +90,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-mocha-test');
+
+  //"grunt-version": "https://github.com/kswedberg/grunt-version/tarball/master"
+  // issue with putting this in the package.json file, is that it updates it's own line since it has version": in it.
+  grunt.loadNpmTasks('grunt-version');
 
   // Default task.
   grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "assemble",
   "description": "Get the rocks out of your socks. Assemble helps you _quickly launch web projects_ using HTML and CSS components, scaffolds, client-side templates, mock-data, CSS pre-processors, markdown, YAML, JSON, sensible configuration defaults and a Grunt.js build system to make it work.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/sellside/assemble",
   "author": {
     "name": "Sellside",


### PR DESCRIPTION
Adding grunt-version to increment the assemble package version when needed.

Can use it to check the version with: `grunt version:check`
Increment the version patch with `grunt version:release`

These are the only options right now, I'll probably be adding some later when we decide how to use it.
