### PR TITLE
Fixing assets path calculation to remove trailing slash

### DIFF
--- a/examples/grid/src/layouts/layout.mustache
+++ b/examples/grid/src/layouts/layout.mustache
@@ -11,7 +11,7 @@ links:
 <html>
   <head>
     <title>{{page.title}}</title>
-    <link rel="stylesheet" href="{{assets}}css/bootstrap.css">
+    <link rel="stylesheet" href="{{assets}}/css/bootstrap.css">
   </head>
   <body>
     {{> navbar }}

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -257,7 +257,7 @@ module.exports = function(grunt) {
           path.relative(
             path.resolve(path.join(dest, relative)),
             path.resolve(assetsPath)
-          ) + path.sep);
+          ));
 
         grunt.verbose.writeln(('\t' + 'Src: '    + srcFile));
         grunt.verbose.writeln(('\t' + 'Dest: '   + destFile));


### PR DESCRIPTION
Updating to remove the trailing slash on the assets path.
Now templates that use the assets path should use it like:

``` html
<link rel="stylesheet" href="{{assets}}/css/bootstrap.css">
```

instead of:

``` html
<link rel="stylesheet" href="{{assets}}css/bootstrap.css">
```

notice the / between the handlebars token and the rest of the
path to the css file.
