### PR TITLE
Updating package.json

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -120,7 +120,6 @@ module.exports = function(grunt) {
         grunt.log.write(('\n' + 'Processing partials...').grey);
 
         partials.forEach(function(filepath) {
-          grunt.verbose.writeln('\t' + filepath.cyan);
           var filename = _.first(filepath.match(assemble.filenameRegex)).replace(assemble.fileExtRegex, '');
           grunt.verbose.writeln(('Processing ' + filename + ' partial').cyan);
           if(complete%increment === 0) {


### PR DESCRIPTION
Updating package.json to set the main property to ./lib/assemble so we're loading the lib instead of the gruntfile.

This allows us to use assemble in other places by requiring it directly...

``` javascript
var assemble = require('assemble');
var frontMatter = assemble.Utils.FrontMatter({});
var results = frontMatter.extract('./path/to/file.hbs');
console.log(results.context);
```

Better naming and conventions for the assemble Utils is another issue that we're working on.
