### PR TITLE
Added a variable for excluding pages from build

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -295,6 +295,11 @@ module.exports = function(grunt) {
               data: pageContext
             };
 
+            if(pageObj.data.published === false){
+              grunt.log.writeln('Page ' + filename.magenta + ' has been set to published = false, '+'skipping.'.yellow);
+              return;
+            }
+
             pages.push(pageObj);
 
             tags = updateTags(tags, pageObj, pageContext);


### PR DESCRIPTION
With this you can use frontmatter to disable rendering of a page when needed. (Useful for prototyping)

```

---
title: Just testing some stuff on this page, it should not be published
published: false

---
```

I explained the justification for this in issue #122

The actual implementation may need some finesse and maybe the variable name should be changed to something else. (like `publish: false`)
