### PR TITLE
Added an option to remove extra whitespace around hbs tags

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -30,8 +30,8 @@ module.exports = function(grunt) {
   //Removes extra whitespace around {{}}-elements somewhat like .mustache does.
   var removeHbsWhitespace = function(assemble,filecontent){
     if(assemble.options.removeHbsWhitespace){
-      filecontent = filecontent.replace(/\n\s*(\{\{\{[^}]+?\}\}\}\n)/gi,"$1");
-      filecontent = filecontent.replace(/\n\s*(\{\{[^}]+?\}\}\n)/gi,"$1");
+      filecontent = filecontent.replace(/(\n|\r|\n\r)[\t ]*(\{\{\{[^}]+?\}\}\})(?=(\n|\r|\n\r))/gi,"$2");
+      filecontent = filecontent.replace(/(\n|\r|\n\r)[\t ]*(\{\{[^}]+?\}\})(?=(\n|\r|\n\r))/gi,"$2");
     }
     return filecontent;
   };


### PR DESCRIPTION
It annoys me and apparently many others that handlebars does not strip extra whitespace around its elements when compiling. 

wycats/handlebars.js#336

This is a quick hack to make it strip that extra whitespace as if the rows with only a single hbs tag were not separate rows. This pull possibly has some bugs in its regexp, but it's a start.

I thought that maybe this should be toggleable by the user, so only by adding an option: removeHbsWhitespace:true to grunt config of assemble will enable this feature. (without it, no ill effects should happen)

With removeHbsWhitespace enabled code like this:

```
{{#each collection}}
<div>{{this}}</div>
{{/each}}
```

normally resulting this:

```
<div>ele1</div>

<div>ele2</div>

<div>ele3</div>
```

would be preprocessed to be like this:

```
{{#each collection}}
<div>{{this}}</div>{{/each}}
```

resulting this:

```
<div>ele1</div>
<div>ele2</div>
<div>ele3</div>
```

This feels more natural and helps creating cleaner and more readable layouts, partials and page code.
