### PR TITLE
Calling registerFunctions and registerPartial functions properly

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
       //assemble.engineLoader = utils.EngineLoader(assemble.options);
       assemble.engine.load(assemble.options.engine);
 
-      var registerFunctions = function(engine) { engine.registerFunctions(); };
+      var registerFunctions = function(engine) { engine.registerFunctions([]); };
       assemble.options.registerFunctions = assemble.options.registerFunctions || registerFunctions;
 
       var registerPartial = function(engine, filename, content) { engine.registerPartial(filename, content); };


### PR DESCRIPTION
Calling registerFunctions and registerPartial properly by passing in the engine...

``` javascript
registerFunctions(assemble.engine);
registerPartial(assemble.engine, 'partialName', content);
```

Now this can be setup properly in the assemble options of a task or target like the following:

``` javascript
assemble: {
  target1: {
    registerFunctions: function(engine) {
      var helperFunctions = {};
      helperFunctions['foo'] = function() { return '<h3>bar</h3>'; };
      engine.registerFunctions(helperFunctions);
    },
    registerPartial: function(engine, name, content) {
      var tmpl = engine.compile(content);
      engine.registerPartial(name, tmpl);
    }
  }
}
```
