### PR TITLE
Fixing filename, adding dirname, and updating tests

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -512,9 +512,10 @@ module.exports = function(grunt) {
 
       // add other page variables to the main context
       context.pageName = currentPage.filename;
-      context.filename = currentPage.filename;
+      context.filename = currentPage.dest;
       context.extname = currentPage.ext;
       context.basename = currentPage.basename;
+      context.dirname = path.dirname(currentPage.dest);
 
       assemble.options.registerPartial(assemble.engine, 'body', page);
 

--- a/test/actual/dates.html
+++ b/test/actual/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Sun May 19 2013 11:47:43 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Sun May 19 2013 12:10:07 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -38,12 +38,16 @@
         <!--
           page.dest: test\actual\dates.html
           this.dest: test\actual\dates.html
+          filename: test\actual\dates.html
+          dirname: test\actual
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\dates.html
           this.dest: test\actual\page.html
+          filename: test\actual\dates.html
+          dirname: test\actual
         -->
         <li><a href="page.html">page</a></li>
       

--- a/test/actual/multi/dest1/alert.html
+++ b/test/actual/multi/dest1/alert.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\alert.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/category.html
+++ b/test/actual/multi/dest1/category.html
@@ -43,156 +43,208 @@
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\category.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\category.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/complex.html
+++ b/test/actual/multi/dest1/complex.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\complex.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/dates.html
+++ b/test/actual/multi/dest1/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Sun May 19 2013 11:47:43 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Sun May 19 2013 12:10:07 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -38,156 +38,208 @@
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\dates.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/helpers.html
+++ b/test/actual/multi/dest1/helpers.html
@@ -93,156 +93,208 @@
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\helpers.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/nav.html
+++ b/test/actual/multi/dest1/nav.html
@@ -40,156 +40,208 @@
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\nav.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/page.html
+++ b/test/actual/multi/dest1/page.html
@@ -47,156 +47,208 @@
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\page.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\page.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/simple3.html
+++ b/test/actual/multi/dest1/simple3.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\simple3.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest1/tags_test.html
+++ b/test/actual/multi/dest1/tags_test.html
@@ -44,156 +44,208 @@
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest1\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest1\tags_test.html
+          dirname: test\actual\multi\dest1
         -->
         <li><a href="../dest2/sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/complex1.html
+++ b/test/actual/multi/dest2/complex1.html
@@ -49,156 +49,208 @@ var foo = function(bar) {
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\complex1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\complex1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/md1.html
+++ b/test/actual/multi/dest2/md1.html
@@ -37,156 +37,208 @@
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\md1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/md2.html
+++ b/test/actual/multi/dest2/md2.html
@@ -37,156 +37,208 @@
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\md2.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\md2.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/simple1.html
+++ b/test/actual/multi/dest2/simple1.html
@@ -37,156 +37,208 @@
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\simple1.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\simple1.html
+          dirname: test\actual\multi\dest2
         -->
         <li><a href="sub-dest/tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/alert.html
+++ b/test/actual/multi/dest2/sub-dest/alert.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\alert.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\alert.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/category.html
+++ b/test/actual/multi/dest2/sub-dest/category.html
@@ -43,156 +43,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\category.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\category.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/complex.html
+++ b/test/actual/multi/dest2/sub-dest/complex.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\complex.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\complex.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/dates.html
+++ b/test/actual/multi/dest2/sub-dest/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Sun May 19 2013 11:47:43 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Sun May 19 2013 12:10:08 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -38,156 +38,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\dates.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\dates.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/helpers.html
+++ b/test/actual/multi/dest2/sub-dest/helpers.html
@@ -93,156 +93,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\helpers.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\helpers.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/nav.html
+++ b/test/actual/multi/dest2/sub-dest/nav.html
@@ -40,156 +40,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\nav.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\nav.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/page.html
+++ b/test/actual/multi/dest2/sub-dest/page.html
@@ -47,156 +47,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\page.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\page.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/simple3.html
+++ b/test/actual/multi/dest2/sub-dest/simple3.html
@@ -33,156 +33,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\simple3.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\simple3.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/multi/dest2/sub-dest/tags_test.html
+++ b/test/actual/multi/dest2/sub-dest/tags_test.html
@@ -44,156 +44,208 @@
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\alert.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\category.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\category2.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\complex.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\dates.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\page.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\nav.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest1\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../../dest1/tags_test2.html">tags_test2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\complex1.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../complex1.html">complex1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\md1.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md1.html">md1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\md2.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../md2.html">md2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\simple1.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="../simple1.html">simple1</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\alert.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="alert.html">alert</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\category.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category.html">category</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\category2.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="category2.html">category2</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\complex.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="complex.html">complex</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\dates.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\helpers.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="helpers.html">helpers</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\page.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="page.html">page</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\nav.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="nav.html">nav</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\simple3.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="simple3.html">simple3</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test.html">tags_test</a></li>
       
         <!--
           page.dest: test\actual\multi\dest2\sub-dest\tags_test.html
           this.dest: test\actual\multi\dest2\sub-dest\tags_test2.html
+          filename: test\actual\multi\dest2\sub-dest\tags_test.html
+          dirname: test\actual\multi\dest2\sub-dest
         -->
         <li><a href="tags_test2.html">tags_test2</a></li>
       

--- a/test/actual/page.html
+++ b/test/actual/page.html
@@ -47,12 +47,16 @@
         <!--
           page.dest: test\actual\page.html
           this.dest: test\actual\dates.html
+          filename: test\actual\page.html
+          dirname: test\actual
         -->
         <li><a href="dates.html">dates</a></li>
       
         <!--
           page.dest: test\actual\page.html
           this.dest: test\actual\page.html
+          filename: test\actual\page.html
+          dirname: test\actual
         -->
         <li><a href="page.html">page</a></li>
       

--- a/test/actual/yaml/associative-arrays.html
+++ b/test/actual/yaml/associative-arrays.html
@@ -50,54 +50,72 @@
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\associative-arrays.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\associative-arrays.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/block-literals.html
+++ b/test/actual/yaml/block-literals.html
@@ -55,54 +55,72 @@ old pond . . . a frog leaps in water’s sound
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\block-literals.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\block-literals.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/comments.html
+++ b/test/actual/yaml/comments.html
@@ -35,54 +35,72 @@ Nothing.
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\comments.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\comments.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/data-files.html
+++ b/test/actual/yaml/data-files.html
@@ -66,54 +66,72 @@
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-files.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\data-files.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/data-types.html
+++ b/test/actual/yaml/data-types.html
@@ -58,54 +58,72 @@
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\data-types.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\data-types.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/document.html
+++ b/test/actual/yaml/document.html
@@ -155,54 +155,72 @@ Suite 16
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\document.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\document.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/lists.html
+++ b/test/actual/yaml/lists.html
@@ -120,54 +120,72 @@
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\lists.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\lists.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/relational-trees.html
+++ b/test/actual/yaml/relational-trees.html
@@ -186,54 +186,72 @@
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\relational-trees.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\relational-trees.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/actual/yaml/variables.html
+++ b/test/actual/yaml/variables.html
@@ -50,54 +50,72 @@ other_thing: *NAME</code></pre>
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\associative-arrays.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="associative-arrays.html">associative-arrays</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\block-literals.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="block-literals.html">block-literals</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\comments.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="comments.html">comments</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\data-files.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-files.html">data-files</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\data-types.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="data-types.html">data-types</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\document.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="document.html">document</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\lists.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="lists.html">lists</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\relational-trees.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="relational-trees.html">relational-trees</a></li>
       
         <!--
           page.dest: test\actual\yaml\variables.html
           this.dest: test\actual\yaml\variables.html
+          filename: test\actual\yaml\variables.html
+          dirname: test\actual\yaml
         -->
         <li><a href="variables.html">variables</a></li>
       

--- a/test/files/layout.hbs
+++ b/test/files/layout.hbs
@@ -19,6 +19,8 @@
         <!--
           page.dest: {{../page.dest}}
           this.dest: {{this.dest}}
+          filename: {{../filename}}
+          dirname: {{../dirname}}
         -->
         <li><a href="{{relative ../page.dest this.dest}}">{{this.basename}}</a></li>
       {{/each}}


### PR DESCRIPTION
Fixing the `filename` on the context so it shows the entire destination path and filename with extension. Now `filename` === `page.dest`.

Adding `dirname` which is just `path.dirname(page.dest);`

Updating tests to show of `filename` and `dirname` for debugging purposes.
