### PR TITLE
Updating `assets` logic to return `.` when path is blank (same folder)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,17 @@ module.exports = function(grunt) {
           'test/actual/multi/dest2/': ['test/files/**/*.{md,markdown}'],
           'test/actual/multi/dest2/sub-dest/': ['test/files/**/*.hbs', '!test/files/layout*.*']
         }
+      },
+      assets: {
+        options: {
+          assets: 'test/actual',
+          layout: 'test/files/layout3.hbs',
+          data: ['test/data/*.json']
+        },
+        files: {
+          'test/actual/': ['test/files/example.hbs'],
+          'test/actual/example/': ['test/files/example.hbs']
+        }
       }
     }
   });

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -264,6 +264,12 @@ module.exports = function(grunt) {
               path.resolve(assetsPath)
             ));
 
+          // if the assets relative path is blank, then it's the same folder
+          // so update to be '.'
+          if(!assemble.options.assets || assemble.options.assets.length === 0) {
+            assemble.options.assets = '.';
+          }
+
           grunt.verbose.writeln(('\t' + 'Src: '    + srcFile));
           grunt.verbose.writeln(('\t' + 'Dest: '   + destFile));
           grunt.verbose.writeln(('\t' + 'Assets: ' + assemble.options.assets));

--- a/test/actual/dates.html
+++ b/test/actual/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Wed May 22 2013 16:55:20 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Fri May 24 2013 13:06:34 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -19,21 +19,27 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  description: 'testing the dates helpers',
   css: '<link rel="stylesheet" href="/css/index.css"/>',
-  js: 'document.write(\'foo bar!\');',
-  filename: 'dates',
-  basename: 'dates',
   src: 'test\\files\\dates.hbs',
+  filename: 'dates',
+  data: 
+   { css: '<link rel="stylesheet" href="/css/index.css"/>',
+     js: 'document.write(\'foo bar!\');',
+     description: 'testing the dates helpers' 
+},
   dest: 'test\\actual\\dates.html',
   assets: 'assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  js: 'document.write(\'foo bar!\');',
+  basename: 'dates',
   ext: '.html',
-  page: [Function],
-  data: 
-   { description: 'testing the dates helpers',
-     css: '<link rel="stylesheet" href="/css/index.css"/>',
-     js: 'document.write(\'foo bar!\');' 
-} }
+  description: 'testing the dates helpers' }
 ```
 
       <ul>

--- a/test/actual/example.html
+++ b/test/actual/example.html
@@ -1,0 +1,66 @@
+<!doctype html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>YAML Test</title>
+    <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+    <link href="./css/layout3.css" rel="stylesheet">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+      
+
+<div>bar</div>
+<div>content from common1.json</div>
+
+
+<div>bar</div>
+<div></div>
+
+    </div>
+
+    <div class="container" style="display: none">
+      <h3>Debug Info</h3>
+      ``` 
+{
+  content: 'content from common1.json',
+  src: 'test\\files\\example.hbs',
+  filename: 'example',
+  data: { foo: 'bar' 
+},
+  dest: 'test\\actual\\example.html',
+  assets: '.',
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'example',
+  ext: '.html' }
+```
+
+      <ul>
+      
+        <!--
+          page.dest: test\actual\example.html
+          this.dest: test\actual\example.html
+          filename: test\actual\example.html
+          dirname: test\actual
+        -->
+        <li><a href="example.html">example</a></li>
+      
+        <!--
+          page.dest: test\actual\example.html
+          this.dest: test\actual\example\example.html
+          filename: test\actual\example.html
+          dirname: test\actual
+        -->
+        <li><a href="example/example.html">example</a></li>
+      
+      </ul>
+    </div>
+  </body>
+</html>

--- a/test/actual/example/example.html
+++ b/test/actual/example/example.html
@@ -1,0 +1,66 @@
+<!doctype html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>YAML Test</title>
+    <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+    <link href="../css/layout3.css" rel="stylesheet">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+      
+
+<div>bar</div>
+<div>content from common1.json</div>
+
+
+<div>bar</div>
+<div></div>
+
+    </div>
+
+    <div class="container" style="display: none">
+      <h3>Debug Info</h3>
+      ``` 
+{
+  content: 'content from common1.json',
+  src: 'test\\files\\example.hbs',
+  filename: 'example',
+  data: { foo: 'bar' 
+},
+  dest: 'test\\actual\\example\\example.html',
+  assets: '..',
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'example',
+  ext: '.html' }
+```
+
+      <ul>
+      
+        <!--
+          page.dest: test\actual\example\example.html
+          this.dest: test\actual\example.html
+          filename: test\actual\example\example.html
+          dirname: test\actual\example
+        -->
+        <li><a href="../example.html">example</a></li>
+      
+        <!--
+          page.dest: test\actual\example\example.html
+          this.dest: test\actual\example\example.html
+          filename: test\actual\example\example.html
+          dirname: test\actual\example
+        -->
+        <li><a href="example.html">example</a></li>
+      
+      </ul>
+    </div>
+  </body>
+</html>

--- a/test/actual/multi/dest1/alert.html
+++ b/test/actual/multi/dest1/alert.html
@@ -17,16 +17,22 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  one: { two: 'This is an alert' 
-},
-  filename: 'alert',
-  basename: 'alert',
   src: 'test\\files\\alert.hbs',
+  filename: 'alert',
+  data: { one: { two: 'This is an alert' 
+} },
   dest: 'test\\actual\\multi\\dest1\\alert.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { one: { two: 'This is an alert' } } }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  one: { two: 'This is an alert' },
+  basename: 'alert',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/category.html
+++ b/test/actual/multi/dest1/category.html
@@ -31,18 +31,24 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  page: [Function],
-  categories: [ 'categories', 'test', 'something' ],
-  filename: 'category',
-  basename: 'category',
   src: 'test\\files\\category.hbs',
+  filename: 'category',
+  data: 
+   { categories: [ 'categories', 'test', 'something', [length]: 3 ],
+     page: { title: 'Categories Test' 
+} },
   dest: 'test\\actual\\multi\\dest1\\category.html',
   assets: '../../assets',
-  ext: '.html',
-  data: 
-   { page: { title: 'Categories Test' 
-},
-     categories: [ 'categories', 'test', 'something' ] } }
+  categories: [ 'categories', 'test', 'something', [length]: 3 ],
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'category',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/complex.html
+++ b/test/actual/multi/dest1/complex.html
@@ -17,17 +17,23 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  foo: 'bar',
+  src: 'test\\files\\complex.hbs',
   version: 2,
   filename: 'complex',
-  basename: 'complex',
-  src: 'test\\files\\complex.hbs',
+  data: { version: 2, foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest1\\complex.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar', version: 2 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'complex',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/dates.html
+++ b/test/actual/multi/dest1/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Wed May 22 2013 16:55:20 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Fri May 24 2013 13:06:34 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -19,21 +19,27 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  description: 'testing the dates helpers',
   css: '<link rel="stylesheet" href="/css/index.css"/>',
-  js: 'document.write(\'foo bar!\');',
-  filename: 'dates',
-  basename: 'dates',
   src: 'test\\files\\dates.hbs',
+  filename: 'dates',
+  data: 
+   { css: '<link rel="stylesheet" href="/css/index.css"/>',
+     js: 'document.write(\'foo bar!\');',
+     description: 'testing the dates helpers' 
+},
   dest: 'test\\actual\\multi\\dest1\\dates.html',
   assets: '../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  js: 'document.write(\'foo bar!\');',
+  basename: 'dates',
   ext: '.html',
-  page: [Function],
-  data: 
-   { description: 'testing the dates helpers',
-     css: '<link rel="stylesheet" href="/css/index.css"/>',
-     js: 'document.write(\'foo bar!\');' 
-} }
+  description: 'testing the dates helpers' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/example.html
+++ b/test/actual/multi/dest1/example.html
@@ -23,16 +23,22 @@
       ``` 
 {
   content: 'content from common1.json',
-  foo: 'bar',
-  filename: 'example',
-  basename: 'example',
   src: 'test\\files\\example.hbs',
+  filename: 'example',
+  data: { foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest1\\example.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar' 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'example',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/helpers.html
+++ b/test/actual/multi/dest1/helpers.html
@@ -70,29 +70,37 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  url: 'http://gist.github.com/jonschlinkert/5193239',
   text: 'helpers.js',
-  links: [ 'one', 'two', 'three' ],
-  moreLinks: 
-   [ { url: 'one', text: 'two' 
-},
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' } ],
-  filename: 'helpers',
-  basename: 'helpers',
   src: 'test\\files\\helpers.hbs',
+  filename: 'helpers',
+  moreLinks: 
+   [ { text: 'two', url: 'one' 
+},
+     { text: 'four', url: 'three' },
+     { text: 'size', url: 'five' },
+     [length]: 3 ],
+  data: 
+   { text: 'helpers.js',
+     moreLinks: 
+      [ { text: 'two', url: 'one' },
+        { text: 'four', url: 'three' },
+        { text: 'size', url: 'five' },
+        [length]: 3 ],
+     links: [ 'one', 'two', 'three', [length]: 3 ],
+     url: 'http://gist.github.com/jonschlinkert/5193239' },
   dest: 'test\\actual\\multi\\dest1\\helpers.html',
   assets: '../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'helpers',
   ext: '.html',
-  page: [Function],
-  data: 
-   { url: 'http://gist.github.com/jonschlinkert/5193239',
-     text: 'helpers.js',
-     links: [ 'one', 'two', 'three' ],
-     moreLinks: 
-      [ { url: 'one', text: 'two' },
-        { url: 'three', text: 'four' },
-        { url: 'five', text: 'size' } ] } }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  url: 'http://gist.github.com/jonschlinkert/5193239' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/nav.html
+++ b/test/actual/multi/dest1/nav.html
@@ -24,15 +24,21 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'nav',
-  basename: 'nav',
   src: 'test\\files\\partials\\nav.hbs',
+  filename: 'nav',
+  data: {
+},
   dest: 'test\\actual\\multi\\dest1\\nav.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'nav',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/page.html
+++ b/test/actual/multi/dest1/page.html
@@ -29,19 +29,35 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'page',
-  basename: 'page',
   src: 'test\\files\\page.hbs',
-  dest: 'test\\actual\\multi\\dest1\\page.html',
-  assets: '../../assets',
-  ext: '.html',
-  page: [Function],
+  filename: 'page',
   data: 
    { title: 'Partials Test',
-     links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] 
+     links: 
+      [ './index',
+        'dest/context',
+        'dest/basic',
+        'dest/markdown',
+        [length]: 4 ] 
 },
+  dest: 'test\\actual\\multi\\dest1\\page.html',
+  assets: '../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'page',
   title: 'Partials Test',
-  links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] }
+  ext: '.html',
+  links: 
+   [ './index',
+     'dest/context',
+     'dest/basic',
+     'dest/markdown',
+     [length]: 4 ] }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/simple3.html
+++ b/test/actual/multi/dest1/simple3.html
@@ -17,16 +17,22 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  foo: 'bar',
-  filename: 'simple3',
-  basename: 'simple3',
   src: 'test\\files\\simple3.hbs',
+  filename: 'simple3',
+  data: { foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest1\\simple3.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar' 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'simple3',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest1/tags_test.html
+++ b/test/actual/multi/dest1/tags_test.html
@@ -31,20 +31,26 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  page: [Function],
-  title: 'Tags Test',
-  tags: [ 'tags', 'test', 'something' ],
-  filename: 'tags_test',
-  basename: 'tags_test',
   src: 'test\\files\\tags_test.hbs',
+  filename: 'tags_test',
+  data: 
+   { tags: [ 'tags', 'test', 'something', [length]: 3 ],
+     page: null,
+     title: 'Tags Test' 
+},
   dest: 'test\\actual\\multi\\dest1\\tags_test.html',
   assets: '../../assets',
-  ext: '.html',
-  data: 
-   { page: null,
-     title: 'Tags Test',
-     tags: [ 'tags', 'test', 'something' ] 
-} }
+  tags: [ 'tags', 'test', 'something', [length]: 3 ],
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'tags_test',
+  title: 'Tags Test',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/complex1.html
+++ b/test/actual/multi/dest2/complex1.html
@@ -33,15 +33,21 @@ var foo = function(bar) {
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'complex1',
-  basename: 'complex1',
   src: 'test\\files\\complex1.md',
+  filename: 'complex1',
+  data: {
+},
   dest: 'test\\actual\\multi\\dest2\\complex1.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'complex1',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/md2.html
+++ b/test/actual/multi/dest2/md2.html
@@ -21,15 +21,21 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'md2',
-  basename: 'md2',
   src: 'test\\files\\md2.markdown',
+  filename: 'md2',
+  data: {
+},
   dest: 'test\\actual\\multi\\dest2\\md2.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'md2',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/simple1.html
+++ b/test/actual/multi/dest2/simple1.html
@@ -21,15 +21,21 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'simple1',
-  basename: 'simple1',
   src: 'test\\files\\simple1.md',
+  filename: 'simple1',
+  data: {
+},
   dest: 'test\\actual\\multi\\dest2\\simple1.html',
   assets: '../../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'simple1',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/alert.html
+++ b/test/actual/multi/dest2/sub-dest/alert.html
@@ -17,16 +17,22 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  one: { two: 'This is an alert' 
-},
-  filename: 'alert',
-  basename: 'alert',
   src: 'test\\files\\alert.hbs',
+  filename: 'alert',
+  data: { one: { two: 'This is an alert' 
+} },
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\alert.html',
   assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { one: { two: 'This is an alert' } } }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  one: { two: 'This is an alert' },
+  basename: 'alert',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/category.html
+++ b/test/actual/multi/dest2/sub-dest/category.html
@@ -31,18 +31,24 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  page: [Function],
-  categories: [ 'categories', 'test', 'something' ],
-  filename: 'category',
-  basename: 'category',
   src: 'test\\files\\category.hbs',
+  filename: 'category',
+  data: 
+   { categories: [ 'categories', 'test', 'something', [length]: 3 ],
+     page: { title: 'Categories Test' 
+} },
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\category.html',
   assets: '../../../assets',
-  ext: '.html',
-  data: 
-   { page: { title: 'Categories Test' 
-},
-     categories: [ 'categories', 'test', 'something' ] } }
+  categories: [ 'categories', 'test', 'something', [length]: 3 ],
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'category',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/complex.html
+++ b/test/actual/multi/dest2/sub-dest/complex.html
@@ -17,17 +17,23 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  foo: 'bar',
+  src: 'test\\files\\complex.hbs',
   version: 2,
   filename: 'complex',
-  basename: 'complex',
-  src: 'test\\files\\complex.hbs',
+  data: { version: 2, foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\complex.html',
   assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar', version: 2 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'complex',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/dates.html
+++ b/test/actual/multi/dest2/sub-dest/dates.html
@@ -9,7 +9,7 @@
     <div class="container">
       
 
-<div>Date: Wed May 22 2013 16:55:20 GMT-0400 (Eastern Daylight Time)</div>
+<div>Date: Fri May 24 2013 13:06:34 GMT-0400 (Eastern Daylight Time)</div>
 
 <div>Born 33 years ago</div>
 
@@ -19,21 +19,27 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  description: 'testing the dates helpers',
   css: '<link rel="stylesheet" href="/css/index.css"/>',
-  js: 'document.write(\'foo bar!\');',
-  filename: 'dates',
-  basename: 'dates',
   src: 'test\\files\\dates.hbs',
+  filename: 'dates',
+  data: 
+   { css: '<link rel="stylesheet" href="/css/index.css"/>',
+     js: 'document.write(\'foo bar!\');',
+     description: 'testing the dates helpers' 
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\dates.html',
   assets: '../../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  js: 'document.write(\'foo bar!\');',
+  basename: 'dates',
   ext: '.html',
-  page: [Function],
-  data: 
-   { description: 'testing the dates helpers',
-     css: '<link rel="stylesheet" href="/css/index.css"/>',
-     js: 'document.write(\'foo bar!\');' 
-} }
+  description: 'testing the dates helpers' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/example.html
+++ b/test/actual/multi/dest2/sub-dest/example.html
@@ -23,16 +23,22 @@
       ``` 
 {
   content: 'content from common1.json',
-  foo: 'bar',
-  filename: 'example',
-  basename: 'example',
   src: 'test\\files\\example.hbs',
+  filename: 'example',
+  data: { foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\example.html',
   assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar' 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'example',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/helpers.html
+++ b/test/actual/multi/dest2/sub-dest/helpers.html
@@ -70,29 +70,37 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  url: 'http://gist.github.com/jonschlinkert/5193239',
   text: 'helpers.js',
-  links: [ 'one', 'two', 'three' ],
-  moreLinks: 
-   [ { url: 'one', text: 'two' 
-},
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' } ],
-  filename: 'helpers',
-  basename: 'helpers',
   src: 'test\\files\\helpers.hbs',
+  filename: 'helpers',
+  moreLinks: 
+   [ { text: 'two', url: 'one' 
+},
+     { text: 'four', url: 'three' },
+     { text: 'size', url: 'five' },
+     [length]: 3 ],
+  data: 
+   { text: 'helpers.js',
+     moreLinks: 
+      [ { text: 'two', url: 'one' },
+        { text: 'four', url: 'three' },
+        { text: 'size', url: 'five' },
+        [length]: 3 ],
+     links: [ 'one', 'two', 'three', [length]: 3 ],
+     url: 'http://gist.github.com/jonschlinkert/5193239' },
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\helpers.html',
   assets: '../../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'helpers',
   ext: '.html',
-  page: [Function],
-  data: 
-   { url: 'http://gist.github.com/jonschlinkert/5193239',
-     text: 'helpers.js',
-     links: [ 'one', 'two', 'three' ],
-     moreLinks: 
-      [ { url: 'one', text: 'two' },
-        { url: 'three', text: 'four' },
-        { url: 'five', text: 'size' } ] } }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  url: 'http://gist.github.com/jonschlinkert/5193239' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/nav.html
+++ b/test/actual/multi/dest2/sub-dest/nav.html
@@ -24,15 +24,21 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'nav',
-  basename: 'nav',
   src: 'test\\files\\partials\\nav.hbs',
+  filename: 'nav',
+  data: {
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\nav.html',
   assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'nav',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/page.html
+++ b/test/actual/multi/dest2/sub-dest/page.html
@@ -29,19 +29,35 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'page',
-  basename: 'page',
   src: 'test\\files\\page.hbs',
-  dest: 'test\\actual\\multi\\dest2\\sub-dest\\page.html',
-  assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
+  filename: 'page',
   data: 
    { title: 'Partials Test',
-     links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] 
+     links: 
+      [ './index',
+        'dest/context',
+        'dest/basic',
+        'dest/markdown',
+        [length]: 4 ] 
 },
+  dest: 'test\\actual\\multi\\dest2\\sub-dest\\page.html',
+  assets: '../../../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'page',
   title: 'Partials Test',
-  links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] }
+  ext: '.html',
+  links: 
+   [ './index',
+     'dest/context',
+     'dest/basic',
+     'dest/markdown',
+     [length]: 4 ] }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/simple3.html
+++ b/test/actual/multi/dest2/sub-dest/simple3.html
@@ -17,16 +17,22 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  foo: 'bar',
-  filename: 'simple3',
-  basename: 'simple3',
   src: 'test\\files\\simple3.hbs',
+  filename: 'simple3',
+  data: { foo: 'bar' 
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\simple3.html',
   assets: '../../../assets',
-  ext: '.html',
-  page: [Function],
-  data: { foo: 'bar' 
-} }
+  foo: 'bar',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'simple3',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/multi/dest2/sub-dest/tags_test.html
+++ b/test/actual/multi/dest2/sub-dest/tags_test.html
@@ -31,20 +31,26 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  page: [Function],
-  title: 'Tags Test',
-  tags: [ 'tags', 'test', 'something' ],
-  filename: 'tags_test',
-  basename: 'tags_test',
   src: 'test\\files\\tags_test.hbs',
+  filename: 'tags_test',
+  data: 
+   { tags: [ 'tags', 'test', 'something', [length]: 3 ],
+     page: null,
+     title: 'Tags Test' 
+},
   dest: 'test\\actual\\multi\\dest2\\sub-dest\\tags_test.html',
   assets: '../../../assets',
-  ext: '.html',
-  data: 
-   { page: null,
-     title: 'Tags Test',
-     tags: [ 'tags', 'test', 'something' ] 
-} }
+  tags: [ 'tags', 'test', 'something', [length]: 3 ],
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'tags_test',
+  title: 'Tags Test',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/page.html
+++ b/test/actual/page.html
@@ -29,19 +29,35 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'page',
-  basename: 'page',
   src: 'test\\files\\page.hbs',
-  dest: 'test\\actual\\page.html',
-  assets: 'assets',
-  ext: '.html',
-  page: [Function],
+  filename: 'page',
   data: 
    { title: 'Partials Test',
-     links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] 
+     links: 
+      [ './index',
+        'dest/context',
+        'dest/basic',
+        'dest/markdown',
+        [length]: 4 ] 
 },
+  dest: 'test\\actual\\page.html',
+  assets: 'assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'page',
   title: 'Partials Test',
-  links: [ './index', 'dest/context', 'dest/basic', 'dest/markdown' ] }
+  ext: '.html',
+  links: 
+   [ './index',
+     'dest/context',
+     'dest/basic',
+     'dest/markdown',
+     [length]: 4 ] }
 ```
 
       <ul>

--- a/test/actual/yaml/associative-arrays.html
+++ b/test/actual/yaml/associative-arrays.html
@@ -31,21 +31,27 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Associative arrays',
-  people: { name: 'John Smith', age: 33 
-},
-  morePeople: { name: 'Grace Jones', age: 21 },
-  filename: 'associative-arrays',
-  basename: 'associative-arrays',
   src: 'test\\yaml\\associative-arrays.hbs',
+  people: { age: 33, name: 'John Smith' 
+},
+  filename: 'associative-arrays',
+  data: 
+   { people: { age: 33, name: 'John Smith' },
+     morePeople: { age: 21, name: 'Grace Jones' },
+     title: 'Associative arrays' },
   dest: 'test\\actual\\yaml\\associative-arrays.html',
   assets: '../assets',
-  ext: '.html',
-  page: [Function],
-  data: 
-   { title: 'Associative arrays',
-     people: { name: 'John Smith', age: 33 },
-     morePeople: { name: 'Grace Jones', age: 21 } } }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  morePeople: { age: 21, name: 'Grace Jones' },
+  basename: 'associative-arrays',
+  title: 'Associative arrays',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/yaml/block-literals.html
+++ b/test/actual/yaml/block-literals.html
@@ -36,21 +36,27 @@ old pond . . . a frog leaps in water’s sound
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Block Literals',
-  poem: 'old pond . . .\na frog leaps in\nwater’s sound\n',
-  another: 'old pond . . . a frog leaps in water’s sound\n',
-  filename: 'block-literals',
-  basename: 'block-literals',
   src: 'test\\yaml\\block-literals.hbs',
+  filename: 'block-literals',
+  data: 
+   { another: 'old pond . . . a frog leaps in water’s sound\n',
+     title: 'Block Literals',
+     poem: 'old pond . . .\na frog leaps in\nwater’s sound\n' 
+},
   dest: 'test\\actual\\yaml\\block-literals.html',
   assets: '../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'block-literals',
+  another: 'old pond . . . a frog leaps in water’s sound\n',
+  title: 'Block Literals',
   ext: '.html',
-  page: [Function],
-  data: 
-   { title: 'Block Literals',
-     poem: 'old pond . . .\na frog leaps in\nwater’s sound\n',
-     another: 'old pond . . . a frog leaps in water’s sound\n' 
-} }
+  poem: 'old pond . . .\na frog leaps in\nwater’s sound\n' }
 ```
 
       <ul>

--- a/test/actual/yaml/comments.html
+++ b/test/actual/yaml/comments.html
@@ -19,16 +19,22 @@ Nothing.
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Comments in YAML front matter',
-  filename: 'comments',
-  basename: 'comments',
   src: 'test\\yaml\\comments.hbs',
+  filename: 'comments',
+  data: { title: 'Comments in YAML front matter' 
+},
   dest: 'test\\actual\\yaml\\comments.html',
   assets: '../assets',
-  ext: '.html',
-  page: [Function],
-  data: { title: 'Comments in YAML front matter' 
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'comments',
+  title: 'Comments in YAML front matter',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/yaml/data-files.html
+++ b/test/actual/yaml/data-files.html
@@ -50,15 +50,21 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  filename: 'data-files',
-  basename: 'data-files',
   src: 'test\\yaml\\data-files.hbs',
+  filename: 'data-files',
+  data: {
+},
   dest: 'test\\actual\\yaml\\data-files.html',
   assets: '../assets',
-  ext: '.html',
-  page: [Function],
-  data: {
-} }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'data-files',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/yaml/data-types.html
+++ b/test/actual/yaml/data-types.html
@@ -33,33 +33,39 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Data Types',
-  dataTypes: 
-   { a: 123,
-     b: '123',
-     c: 123,
-     e: '123',
-     f: 'Yes',
-     g: 'Yes',
-     h: 'Yes we have No bananas' 
-},
-  filename: 'data-types',
-  basename: 'data-types',
   src: 'test\\yaml\\data-types.hbs',
+  filename: 'data-types',
+  data: 
+   { dataTypes: 
+      { e: '123',
+        b: '123',
+        f: 'Yes',
+        c: 123,
+        g: 'Yes',
+        h: 'Yes we have No bananas',
+        a: 123 
+},
+     title: 'Data Types' },
   dest: 'test\\actual\\yaml\\data-types.html',
   assets: '../assets',
-  ext: '.html',
-  page: [Function],
-  data: 
-   { title: 'Data Types',
-     dataTypes: 
-      { a: 123,
-        b: '123',
-        c: 123,
-        e: '123',
-        f: 'Yes',
-        g: 'Yes',
-        h: 'Yes we have No bananas' } } }
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'data-types',
+  dataTypes: 
+   { e: '123',
+     b: '123',
+     f: 'Yes',
+     c: 123,
+     g: 'Yes',
+     h: 'Yes we have No bananas',
+     a: 123 },
+  title: 'Data Types',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/actual/yaml/document.html
+++ b/test/actual/yaml/document.html
@@ -116,61 +116,69 @@ Suite 16
       <h3>Debug Info</h3>
       ``` 
 {
-  receipt: 'Oz-Ware Purchase Invoice',
-  date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
-  prettyDate: '<%= grunt.template.date(date, \'yyyy-mm-dd\') %>',
-  customer: { given: 'Dorothy', family: 'Gale' 
-},
-  items: 
-   [ { part_no: 'A4786',
-       descrip: 'Water Bucket (Filled)',
-       price: 1.47,
-       quantity: 4 },
-     { part_no: 'E1628',
-       descrip: 'High Heeled "Ruby" Slippers',
-       size: 8,
-       price: 100.27,
-       quantity: 1 } ],
-  'bill-to': 
-   { street: '123 Tornado Alley\nSuite 16\n',
-     city: 'East Centerville',
-     state: 'KS' },
   'ship-to': 
-   { street: '123 Tornado Alley\nSuite 16\n',
-     city: 'East Centerville',
-     state: 'KS' },
+   { city: 'East Centerville',
+     state: 'KS',
+     street: '123 Tornado Alley\nSuite 16\n' 
+},
+  receipt: 'Oz-Ware Purchase Invoice',
+  assets: '../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  customer: { given: 'Dorothy', family: 'Gale' },
+  date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
+  dest: 'test\\actual\\yaml\\document.html',
+  basename: 'document',
+  items: 
+   [ { descrip: 'Water Bucket (Filled)',
+       part_no: 'A4786',
+       quantity: 4,
+       price: 1.47 },
+     { descrip: 'High Heeled "Ruby" Slippers',
+       part_no: 'E1628',
+       quantity: 1,
+       price: 100.27,
+       size: 8 },
+     [length]: 2 ],
+  src: 'test\\yaml\\document.hbs',
+  data: 
+   { 'ship-to': 
+      { city: 'East Centerville',
+        state: 'KS',
+        street: '123 Tornado Alley\nSuite 16\n' },
+     receipt: 'Oz-Ware Purchase Invoice',
+     customer: { given: 'Dorothy', family: 'Gale' },
+     date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
+     items: 
+      [ { descrip: 'Water Bucket (Filled)',
+          part_no: 'A4786',
+          quantity: 4,
+          price: 1.47 },
+        { descrip: 'High Heeled "Ruby" Slippers',
+          part_no: 'E1628',
+          quantity: 1,
+          price: 100.27,
+          size: 8 },
+        [length]: 2 ],
+     prettyDate: '<%= grunt.template.date(date, \'yyyy-mm-dd\') %>',
+     specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\n',
+     'bill-to': 
+      { city: 'East Centerville',
+        state: 'KS',
+        street: '123 Tornado Alley\nSuite 16\n' } },
+  prettyDate: '<%= grunt.template.date(date, \'yyyy-mm-dd\') %>',
   specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\n',
   filename: 'document',
-  basename: 'document',
-  src: 'test\\yaml\\document.hbs',
-  dest: 'test\\actual\\yaml\\document.html',
-  assets: '../assets',
   ext: '.html',
-  page: [Function],
-  data: 
-   { receipt: 'Oz-Ware Purchase Invoice',
-     date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
-     prettyDate: '<%= grunt.template.date(date, \'yyyy-mm-dd\') %>',
-     customer: { given: 'Dorothy', family: 'Gale' },
-     items: 
-      [ { part_no: 'A4786',
-          descrip: 'Water Bucket (Filled)',
-          price: 1.47,
-          quantity: 4 },
-        { part_no: 'E1628',
-          descrip: 'High Heeled "Ruby" Slippers',
-          size: 8,
-          price: 100.27,
-          quantity: 1 } ],
-     'bill-to': 
-      { street: '123 Tornado Alley\nSuite 16\n',
-        city: 'East Centerville',
-        state: 'KS' },
-     'ship-to': 
-      { street: '123 Tornado Alley\nSuite 16\n',
-        city: 'East Centerville',
-        state: 'KS' },
-     specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\n' } }
+  'bill-to': 
+   { city: 'East Centerville',
+     state: 'KS',
+     street: '123 Tornado Alley\nSuite 16\n' } }
 ```
 
       <ul>

--- a/test/actual/yaml/lists.html
+++ b/test/actual/yaml/lists.html
@@ -91,41 +91,51 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Almost a Haiku',
-  attributes: [ 'attr1', 'attr2', 'attr3' ],
-  methods: [ 'getter', 'setter' ],
-  movies: 
-   [ 'Casablanca',
-     'North by Northwest',
-     'The Man Who Wasn\'t There' ],
-  groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice' ],
-  people: 
-   [ { name: 'John Smith', age: 33 
-},
-     { name: 'Mary Smith', age: 27 } ],
-  men: [ 'John Smith', 'Bill Jones' ],
-  women: [ 'Mary Smith', 'Susan Williams' ],
-  filename: 'lists',
-  basename: 'lists',
   src: 'test\\yaml\\lists.hbs',
-  dest: 'test\\actual\\yaml\\lists.html',
-  assets: '../assets',
-  ext: '.html',
-  page: [Function],
+  people: 
+   [ { age: 33, name: 'John Smith' 
+},
+     { age: 27, name: 'Mary Smith' },
+     [length]: 2 ],
+  filename: 'lists',
   data: 
-   { title: 'Almost a Haiku',
-     attributes: [ 'attr1', 'attr2', 'attr3' ],
-     methods: [ 'getter', 'setter' ],
+   { people: 
+      [ { age: 33, name: 'John Smith' },
+        { age: 27, name: 'Mary Smith' },
+        [length]: 2 ],
+     methods: [ 'getter', 'setter', [length]: 2 ],
+     women: [ 'Mary Smith', 'Susan Williams', [length]: 2 ],
+     groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice', [length]: 4 ],
+     men: [ 'John Smith', 'Bill Jones', [length]: 2 ],
+     title: 'Almost a Haiku',
      movies: 
       [ 'Casablanca',
         'North by Northwest',
-        'The Man Who Wasn\'t There' ],
-     groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice' ],
-     people: 
-      [ { name: 'John Smith', age: 33 },
-        { name: 'Mary Smith', age: 27 } ],
-     men: [ 'John Smith', 'Bill Jones' ],
-     women: [ 'Mary Smith', 'Susan Williams' ] } }
+        'The Man Who Wasn\'t There',
+        [length]: 3 ],
+     attributes: [ 'attr1', 'attr2', 'attr3', [length]: 3 ] },
+  dest: 'test\\actual\\yaml\\lists.html',
+  assets: '../assets',
+  methods: [ 'getter', 'setter', [length]: 2 ],
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  women: [ 'Mary Smith', 'Susan Williams', [length]: 2 ],
+  groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice', [length]: 4 ],
+  men: [ 'John Smith', 'Bill Jones', [length]: 2 ],
+  basename: 'lists',
+  title: 'Almost a Haiku',
+  ext: '.html',
+  movies: 
+   [ 'Casablanca',
+     'North by Northwest',
+     'The Man Who Wasn\'t There',
+     [length]: 3 ],
+  attributes: [ 'attr1', 'attr2', 'attr3', [length]: 3 ] }
 ```
 
       <ul>

--- a/test/actual/yaml/relational-trees.html
+++ b/test/actual/yaml/relational-trees.html
@@ -132,91 +132,99 @@
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'Relational Trees - References',
-  steps: 
-   [ { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5.4,
-          pulseDuration: 12,
-          repetition: 1000,
-          spotSize: '1mm' 
-} },
-     { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5,
-          pulseDuration: 10,
-          repetition: 500,
-          spotSize: '2mm' } },
-     { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5.4,
-          pulseDuration: 12,
-          repetition: 1000,
-          spotSize: '1mm' } },
-     { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5,
-          pulseDuration: 10,
-          repetition: 500,
-          spotSize: '2mm' } },
-     { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5.4,
-          pulseDuration: 12,
-          repetition: 1000,
-          spotSize: '1mm' } },
-     { step: 
-        { instrument: 'Lasik 2000',
-          pulseEnergy: 5,
-          pulseDuration: 10,
-          repetition: 500,
-          spotSize: '2mm' } } ],
-  filename: 'relational-trees',
-  basename: 'relational-trees',
   src: 'test\\yaml\\relational-trees.hbs',
-  dest: 'test\\actual\\yaml\\relational-trees.html',
-  assets: '../assets',
-  ext: '.html',
-  page: [Function],
+  filename: 'relational-trees',
   data: 
    { title: 'Relational Trees - References',
      steps: 
       [ { step: 
-           { instrument: 'Lasik 2000',
-             pulseEnergy: 5.4,
+           { repetition: 1000,
              pulseDuration: 12,
-             repetition: 1000,
-             spotSize: '1mm' } },
-        { step: 
-           { instrument: 'Lasik 2000',
-             pulseEnergy: 5,
-             pulseDuration: 10,
-             repetition: 500,
-             spotSize: '2mm' } },
-        { step: 
-           { instrument: 'Lasik 2000',
              pulseEnergy: 5.4,
-             pulseDuration: 12,
-             repetition: 1000,
-             spotSize: '1mm' } },
+             spotSize: '1mm',
+             instrument: 'Lasik 2000' 
+} },
         { step: 
-           { instrument: 'Lasik 2000',
-             pulseEnergy: 5,
+           { repetition: 500,
              pulseDuration: 10,
-             repetition: 500,
-             spotSize: '2mm' } },
+             pulseEnergy: 5,
+             spotSize: '2mm',
+             instrument: 'Lasik 2000' } },
         { step: 
-           { instrument: 'Lasik 2000',
+           { repetition: 1000,
+             pulseDuration: 12,
              pulseEnergy: 5.4,
-             pulseDuration: 12,
-             repetition: 1000,
-             spotSize: '1mm' } },
+             spotSize: '1mm',
+             instrument: 'Lasik 2000' } },
         { step: 
-           { instrument: 'Lasik 2000',
-             pulseEnergy: 5,
+           { repetition: 500,
              pulseDuration: 10,
-             repetition: 500,
-             spotSize: '2mm' } } ] } }
+             pulseEnergy: 5,
+             spotSize: '2mm',
+             instrument: 'Lasik 2000' } },
+        { step: 
+           { repetition: 1000,
+             pulseDuration: 12,
+             pulseEnergy: 5.4,
+             spotSize: '1mm',
+             instrument: 'Lasik 2000' } },
+        { step: 
+           { repetition: 500,
+             pulseDuration: 10,
+             pulseEnergy: 5,
+             spotSize: '2mm',
+             instrument: 'Lasik 2000' } },
+        [length]: 6 ] },
+  dest: 'test\\actual\\yaml\\relational-trees.html',
+  assets: '../assets',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  basename: 'relational-trees',
+  title: 'Relational Trees - References',
+  ext: '.html',
+  steps: 
+   [ { step: 
+        { repetition: 1000,
+          pulseDuration: 12,
+          pulseEnergy: 5.4,
+          spotSize: '1mm',
+          instrument: 'Lasik 2000' } },
+     { step: 
+        { repetition: 500,
+          pulseDuration: 10,
+          pulseEnergy: 5,
+          spotSize: '2mm',
+          instrument: 'Lasik 2000' } },
+     { step: 
+        { repetition: 1000,
+          pulseDuration: 12,
+          pulseEnergy: 5.4,
+          spotSize: '1mm',
+          instrument: 'Lasik 2000' } },
+     { step: 
+        { repetition: 500,
+          pulseDuration: 10,
+          pulseEnergy: 5,
+          spotSize: '2mm',
+          instrument: 'Lasik 2000' } },
+     { step: 
+        { repetition: 1000,
+          pulseDuration: 12,
+          pulseEnergy: 5.4,
+          spotSize: '1mm',
+          instrument: 'Lasik 2000' } },
+     { step: 
+        { repetition: 500,
+          pulseDuration: 10,
+          pulseEnergy: 5,
+          spotSize: '2mm',
+          instrument: 'Lasik 2000' } },
+     [length]: 6 ] }
 ```
 
       <ul>

--- a/test/actual/yaml/variables.html
+++ b/test/actual/yaml/variables.html
@@ -31,21 +31,27 @@ other_thing: *NAME</code></pre>
       <h3>Debug Info</h3>
       ``` 
 {
-  title: 'YAML Variables',
-  one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
-  two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
-  filename: 'variables',
-  basename: 'variables',
   src: 'test\\yaml\\variables.hbs',
+  filename: 'variables',
+  data: 
+   { two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
+     one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
+     title: 'YAML Variables' 
+},
   dest: 'test\\actual\\yaml\\variables.html',
   assets: '../assets',
-  ext: '.html',
-  page: [Function],
-  data: 
-   { title: 'YAML Variables',
-     one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
-     two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!' 
-} }
+  two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
+  page: 
+   { [Function]
+     [arguments]: null,
+     [caller]: null,
+     [name]: '',
+     [prototype]: { [constructor]: [Circular] },
+     [length]: 2 },
+  one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
+  basename: 'variables',
+  title: 'YAML Variables',
+  ext: '.html' }
 ```
 
       <ul>

--- a/test/files/layout3.hbs
+++ b/test/files/layout3.hbs
@@ -1,0 +1,31 @@
+<!doctype html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>{{#if title}}{{title}}{{else}}YAML Test{{/if}}</title>
+    <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+    <link href="{{assets}}/css/layout3.css" rel="stylesheet">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+      {{> body }}
+    </div>
+
+    <div class="container" style="display: none">
+      <h3>Debug Info</h3>
+      {{inspect page}}
+
+      <ul>
+      {{#each pages}}
+        <!--
+          page.dest: {{../page.dest}}
+          this.dest: {{this.dest}}
+          filename: {{../filename}}
+          dirname: {{../dirname}}
+        -->
+        <li><a href="{{relative ../page.dest this.dest}}">{{this.basename}}</a></li>
+      {{/each}}
+      </ul>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Updating to return `.` when the `assets` path calculates to be blank, which is the same path as the current page. This fixes #139 
