### PR TITLE
Make partials in subfolder possible

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -66,7 +66,9 @@ module.exports = function(grunt) {
       var registerFunctions = function(engine) { engine.registerFunctions(); };
       assemble.options.registerFunctions = assemble.options.registerFunctions || registerFunctions;
 
-      var registerPartial = function(engine, filename, content) { engine.registerPartial(filename, content); };
+      var registerPartial = function(engine, filename, content) {
+        engine.registerPartial(_.first(filename.match(assemble.filenameRegex)).replace(assemble.fileExtRegex, ''), content);
+      };
       assemble.options.registerPartial = assemble.options.registerPartial || registerPartial;
 
       assemble.fileExt = extension(src);
@@ -127,8 +129,7 @@ module.exports = function(grunt) {
         grunt.verbose.write(('\n' + 'Processing partials...\n').grey);
 
         partials.forEach(function(filepath) {
-          var filename = _.first(filepath.match(assemble.filenameRegex)).replace(assemble.fileExtRegex, '');
-          grunt.verbose.ok(('Processing ' + filename.cyan + ' partial'));
+          grunt.verbose.ok(('Processing ' + filepath.cyan + ' partial'));
 
           var partial = grunt.file.read(filepath);
 
@@ -137,10 +138,10 @@ module.exports = function(grunt) {
 
           // get the data
           var partialInfo = assemble.data.readYFM(partial, {fromFile: false});
-          assemble.options.data[filename] = _.extend(partialInfo.context || {}, assemble.options.data[filename] || {});
+          assemble.options.data[filepath] = _.extend(partialInfo.context || {}, assemble.options.data[filepath] || {});
 
           // register the partial
-          assemble.options.registerPartial(assemble.engine, filename, partialInfo.content);
+          assemble.options.registerPartial(assemble.engine, filepath, partialInfo.content);
 
           complete++;
         });


### PR DESCRIPTION
With this patch it's possible to handle the partial names more flexible.

Not only the filename of the partial is passed to registerPartial()
but the whole path. This makes it possible to use nested partials
in subfolders.

The default behaviour stays the same by adapting the default
registerPartial() method.
