### PR TITLE
Fixing engine factory to return the underlying engine properly.

### DIFF
--- a/lib/engine/index.js
+++ b/lib/engine/index.js
@@ -4,7 +4,6 @@ var grunt = require('grunt');
 var EngineFactory = function() {
   'use strict';
 
-  var engine = null;
   var engineName = '';
   var extensions = require('./extensions');
 
@@ -13,12 +12,12 @@ var EngineFactory = function() {
     return fn && getType.toString.call(fn) === '[object Function]';
   };
 
-  var tryRequireEngine = function(eng) {
+  var tryRequireEngine = function(eng, obj) {
     try {
-      engine = require('assemble-' + eng);
+      obj.engine = require('assemble-' + eng);
     } catch(ex1) {
       try {
-        engine = require(eng);
+        obj.engine = require(eng);
       } catch(ex2) {
         grunt.log.writeln('Error loading engine: ' + eng);
         grunt.log.writeln(ex2);
@@ -28,44 +27,44 @@ var EngineFactory = function() {
 
   var load = function(eng) {
     engineName = eng;
-    tryRequireEngine(eng);
-    if(!engine) {
+    tryRequireEngine(eng, this);
+    if(!this.engine) {
       return false;
     }
     return this;
   };
 
   var init = function(options) {
-    if(functionExists(engine.init)) {
-      engine.init(options);
+    if(functionExists(this.engine.init)) {
+      this.engine.init(options);
     }
   };
 
   var compile = function(src, options, callback) {
-    if(!functionExists(engine.compile)) {
+    if(!functionExists(this.engine.compile)) {
       grunt.log.writeln(engineName + ' does not support compile.');
       callback(engineName + ' does not support compile.', null);
     }
-    engine.compile(src, options, callback);
+    this.engine.compile(src, options, callback);
   };
 
   var render = function(tmpl, options, callback) {
-    if(!functionExists(engine.render)) {
+    if(!functionExists(this.engine.render)) {
       grunt.log.writeln(engineName + ' does not support render.');
       callback(engineName + ' does not support render.', null);
     }
-    engine.render(tmpl, options, callback);
+    this.engine.render(tmpl, options, callback);
   };
   // Helpers, filters etc. depending on template engine
   var registerFunctions = function() {
-    if(functionExists(engine.registerFunctions)) {
-      engine.registerFunctions();
+    if(functionExists(this.engine.registerFunctions)) {
+      this.engine.registerFunctions();
     }
   };
 
   var registerPartial = function(filename, content) {
-    if(functionExists(engine.registerPartial)) {
-      engine.registerPartial(filename, content);
+    if(functionExists(this.engine.registerPartial)) {
+      this.engine.registerPartial(filename, content);
     }
   };
 
@@ -76,8 +75,7 @@ var EngineFactory = function() {
     render: render,
     registerFunctions: registerFunctions,
     registerPartial: registerPartial,
-    extensions: extensions,
-    engine: engine
+    extensions: extensions
   };
 
 };


### PR DESCRIPTION
There was a bug with the `engine.engine` property being `null` and not getting set properly. This fix makes sure the correct `engine` property is returned.
