### PR TITLE
Fixing helpers tests

### DIFF
--- a/test/engine_test.js
+++ b/test/engine_test.js
@@ -65,7 +65,7 @@ describe('Loading default handlebars engine', function() {
       var engine = assembleEngine.load('handlebars');
       engine.init({
         cwd: __dirname,
-        helpers: './lib/helpers.js'
+        helpers: './helpers/helpers.js'
       });
       runTest(engine, done);
     });
@@ -74,14 +74,14 @@ describe('Loading default handlebars engine', function() {
       var engine = assembleEngine.load('handlebars');
       engine.init({
         cwd: __dirname,
-        helpers: './lib/**/*.js'
+        helpers: './helpers/**/*.js'
       });
       runTest(engine, done);
     });
 
     it('loads a custom helper without needing to set the cwd', function(done) {
       var engine = assembleEngine.load('handlebars');
-      engine.init({helpers: './test/lib/**/*.js'});
+      engine.init({helpers: './test/helpers/**/*.js'});
       var expected = '<!-- foo2 -->\n<!-- bar -->';
       engine.compile("{{{foo2 'bar'}}}", null, function(err, tmpl) {
         if(err) {


### PR DESCRIPTION
The helpers used in the helpers tests were moved to a different folder and needed to be updated in the test cases.
