### PR TITLE
Improve pages collection url references.

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -317,6 +317,18 @@ module.exports = function(grunt) {
               page: page,
               data: pageContext
             };
+            
+            if(assemble.options.urlroot){
+              var from = assemble.options.urlroot;
+              var to = destFile;
+
+              var fromDirname = path.dirname(path.normalize(from));
+              var toDirname = path.normalize(path.dirname(to));
+              var toBasename = path.basename(to);
+              var relativePath = path.relative(fromDirname, toDirname);
+              pageObj.url = path.join(relativePath, toBasename).replace(/\\/g, "/");
+              pageObj.url_stripped = pageObj.url.replace(/index.html$/i,'');
+            }
 
             if(pageObj.data.published === false) {
               grunt.log.write('\n>> Skipping "' + path.basename(srcFile).grey + '" since ' + '"published: false"'.cyan + ' was set.');


### PR DESCRIPTION
When I was creating sitemap and navigation to my page, I faced plenty of issues with paths. Since I have the published site in `build` and the sourcecodes for it in `src` I was constantly doing hacks to get around the fact that all the path variables under a single page in `pages` collection contain these paths.

This a sample of a single page in `pages` collection:

``` js
     { dirname: 'build/blog/first-blog-post',
       filename: 'index.html',
       pageName: 'index.html',
       pagename: 'index.html',
       basename: 'index',
       src: 'src/blog/first-blog-post/index.html.hbs',
       dest: 'build/blog/first-blog-post/index.html',
       assets: '../..',
       ext: '',
       extname: '',
       page: [Function],
       data: [Object],
       match: [Object] },
```

Now if I want to print out all the pages with links pointing to them, I have to remove the `build/` part from the path as that's where the root of my site is.

This pull request adds two new attributes `url` and `url_stripped` to the mix:

``` js
     { dirname: 'build/blog/first-blog-post',
       filename: 'index.html',
       pageName: 'index.html',
       pagename: 'index.html',
       basename: 'index',
       src: 'src/blog/first-blog-post/index.html.hbs',
       dest: 'build/blog/first-blog-post/index.html',
       assets: '../..',
       ext: '',
       extname: '',
       page: [Function],
       data: [Object],
       url: 'blog/first-blog-post/index.html',
       url_stripped: 'blog/first-blog-post/',
       match: [Object] },
```

These two attributes only get added if the user has told assemble where the root of the site is in assemble.options:

``` js
assemble: {
  options: {
    urlroot:'build/index.html',
...
```

The `url` attribute should be quite clear, it's the url to the page from the root of the site. The `url_stripped` is a handy way to clean up the _invisible_ index.html files from paths. It also helps when sorting pages etc.

Here's a small example on listing the pages with this approach:

``` html
<ul>
{{#withSort pages "url_stripped"}}
    <li>{{this.url_stripped}} - <a href="{{relative ../this.page.url this.url_stripped}}">{{this.data.title}}</a></li>
{{/withSort}}
</ul>
```

As you can see, it's quite easy to use and produces nice looking urls too.

Related to this, I found a sorting bug in the withSort and did a pull request for it together with my other pull request related to it.

Thoughts?
