### PR TITLE
Adding a better error message when an engine isn't found.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "assemble-handlebars": "https://github.com/assemble/assemble-handlebars/tarball/master",
     "highlight.js": "~7.3.0",
     "inflection": "~1.2.6",
     "js-yaml": "~2.1.0",


### PR DESCRIPTION
Just adding some instructions on how to install an engine that isn't found.
