### PR TITLE
Fixing issue with $ in page content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,4 +219,8 @@ module.exports = function(grunt) {
 
   // Build
   grunt.registerTask('docs', ['assemble-internal']);
+
+  // Debugging
+  grunt.registerTask('debug', ['clean', 'assemble']);
+  
 };

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -566,7 +566,7 @@ module.exports = function(grunt) {
       context.pageName = currentPage.filename;
 
       //assemble.options.registerPartial(assemble.engine, 'body', page);
-      page = layout.layout.replace(assemble.engine.bodyRegex, page);
+      page = layout.layout.replace(assemble.engine.bodyRegex, function() { return page; });
 
       assemble.engine.render(page, context, function(err, content) {
         if(err) {

--- a/test/actual/multi/dest1/helpers.html
+++ b/test/actual/multi/dest1/helpers.html
@@ -35,16 +35,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1376517008064">
-<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1376517008064">
-<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1376517008064">
+<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1377971442247">
+<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1377971442247">
+<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1377971442247">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../../assets/js/js/bootstrap.js?v=1376517008064"></script>
-<script src="../../../assets/js/js/responsive.js?v=1376517008064"></script>
-<script src="../../../assets/js/js/main.js?v=1376517008064"></script>
+<script src="../../../assets/js/js/bootstrap.js?v=1377971442247"></script>
+<script src="../../../assets/js/js/responsive.js?v=1377971442247"></script>
+<script src="../../../assets/js/js/main.js?v=1377971442247"></script>
 
 
 <h2>custom variables</h2>
@@ -109,9 +109,26 @@ Example of using a custom "js" helper.
       <h2>Debug Info</h2>
       <pre class="json">
 [ 'test/helpers/helper-*.js',
+  _page: 'all',
+  pagename: 'helpers.html',
+  title: 'Helpers and custom variables',
   styles: '<link rel="stylesheet" href="css/index.css"/>',
-  filename: 'helpers.html',
-  basename: 'helpers',
+  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
+  ext: '.html',
+  extname: '.html',
+  dest: 'test/actual/multi/dest1/helpers.html',
+  assets: '../../assets',
+  javascripts: [ 'js/bootstrap.js',
+    'js/responsive.js',
+    'js/main.js',
+    [length]: 3 ],
+  script: 'document.write(\'foo bar!\');',
+  stylesheets: [ 'css/bootstrap.css',
+    'css/responsive.css',
+    'css/main.css',
+    [length]: 3 ],
+  src: 'test/fixtures/pages/helpers.hbs',
+  dirname: 'test/actual/multi/dest1',
   data: { title: 'Helpers and custom variables',
     description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
     stylesheets: 
@@ -126,28 +143,11 @@ Example of using a custom "js" helper.
        [length]: 3 ],
     styles: '<link rel="stylesheet" href="css/index.css"/>',
     script: 'document.write(\'foo bar!\');' },
-  src: 'test/fixtures/pages/helpers.hbs',
-  assets: '../../assets',
-  _page: 'all',
-  dest: 'test/actual/multi/dest1/helpers.html',
-  pagename: 'helpers.html',
-  title: 'Helpers and custom variables',
-  [length]: 1,
-  extname: '.html',
-  stylesheets: [ 'css/bootstrap.css',
-    'css/responsive.css',
-    'css/main.css',
-    [length]: 3 ],
-  script: 'document.write(\'foo bar!\');',
   pageName: 'helpers.html',
-  javascripts: [ 'js/bootstrap.js',
-    'js/responsive.js',
-    'js/main.js',
-    [length]: 3 ],
-  ext: '.html',
-  dirname: 'test/actual/multi/dest1',
   page: '\n<div class="page-header">\n  <h1>{{title}}</h1>\n  <p class="lead">{{description}}</p>\n</div>\n\n<h2>css helper</h2>\nExample of using a custom "css" helper.\n{{css stylesheets}}\n\n\n<h2>js helper</h2>\nExample of using a custom "js" helper.\n{{js javascripts}}\n\n\n<h2>custom variables</h2>\n{{{styles}}}\n<script>{{{script}}}</script>\n',
-  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n' ]
+  basename: 'helpers',
+  [length]: 1,
+  filename: 'helpers.html' ]
 </pre>
     </div>
 

--- a/test/actual/multi/dest1/helpers.md
+++ b/test/actual/multi/dest1/helpers.md
@@ -11,16 +11,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../assets/css/css/bootstrap.css?v=1376517007534">
-<link rel="stylesheet" href="../../assets/css/css/responsive.css?v=1376517007534">
-<link rel="stylesheet" href="../../assets/css/css/main.css?v=1376517007534">
+<link rel="stylesheet" href="../../assets/css/css/bootstrap.css?v=1377971441749">
+<link rel="stylesheet" href="../../assets/css/css/responsive.css?v=1377971441749">
+<link rel="stylesheet" href="../../assets/css/css/main.css?v=1377971441749">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../assets/js/js/bootstrap.js?v=1376517007534"></script>
-<script src="../../assets/js/js/responsive.js?v=1376517007534"></script>
-<script src="../../assets/js/js/main.js?v=1376517007534"></script>
+<script src="../../assets/js/js/bootstrap.js?v=1377971441749"></script>
+<script src="../../assets/js/js/responsive.js?v=1377971441749"></script>
+<script src="../../assets/js/js/main.js?v=1377971441749"></script>
 
 
 <h2>custom variables</h2>
@@ -32,9 +32,26 @@ Example of using a custom "js" helper.
 ## Debug Info
 ``` json
 [ 'test/helpers/helper-*.js',
+  _page: 'all',
+  pagename: 'helpers.md',
+  title: 'Helpers and custom variables',
   styles: '<link rel="stylesheet" href="css/index.css"/>',
-  filename: 'helpers.md',
-  basename: 'helpers',
+  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
+  ext: '.md',
+  extname: '.md',
+  dest: 'test/actual/multi/dest1/helpers.md',
+  assets: '../../assets',
+  javascripts: [ 'js/bootstrap.js',
+    'js/responsive.js',
+    'js/main.js',
+    [length]: 3 ],
+  script: 'document.write(\'foo bar!\');',
+  stylesheets: [ 'css/bootstrap.css',
+    'css/responsive.css',
+    'css/main.css',
+    [length]: 3 ],
+  src: 'test/fixtures/pages/helpers.hbs',
+  dirname: 'test/actual/multi/dest1',
   data: { title: 'Helpers and custom variables',
     description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
     stylesheets: 
@@ -49,28 +66,11 @@ Example of using a custom "js" helper.
        [length]: 3 ],
     styles: '<link rel="stylesheet" href="css/index.css"/>',
     script: 'document.write(\'foo bar!\');' },
-  src: 'test/fixtures/pages/helpers.hbs',
-  assets: '../../assets',
-  _page: 'all',
-  dest: 'test/actual/multi/dest1/helpers.md',
-  pagename: 'helpers.md',
-  title: 'Helpers and custom variables',
-  [length]: 1,
-  extname: '.md',
-  stylesheets: [ 'css/bootstrap.css',
-    'css/responsive.css',
-    'css/main.css',
-    [length]: 3 ],
-  script: 'document.write(\'foo bar!\');',
   pageName: 'helpers.md',
-  javascripts: [ 'js/bootstrap.js',
-    'js/responsive.js',
-    'js/main.js',
-    [length]: 3 ],
-  ext: '.md',
-  dirname: 'test/actual/multi/dest1',
   page: '\n<div class="page-header">\n  <h1>{{title}}</h1>\n  <p class="lead">{{description}}</p>\n</div>\n\n<h2>css helper</h2>\nExample of using a custom "css" helper.\n{{css stylesheets}}\n\n\n<h2>js helper</h2>\nExample of using a custom "js" helper.\n{{js javascripts}}\n\n\n<h2>custom variables</h2>\n{{{styles}}}\n<script>{{{script}}}</script>\n',
-  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n' ]
+  basename: 'helpers',
+  [length]: 1,
+  filename: 'helpers.md' ]
 ```
 
 

--- a/test/actual/multi/dest1/html-helpers.html
+++ b/test/actual/multi/dest1/html-helpers.html
@@ -133,8 +133,19 @@
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ filename: 'html-helpers.html',
-  basename: 'html-helpers',
+{ _page: 'all',
+  pagename: 'html-helpers.html',
+  extname: '.html',
+  moreLinks: 
+   [ { url: 'one', text: 'two' },
+     { url: 'three', text: 'four' },
+     { url: 'five', text: 'size' },
+     [length]: 3 ],
+  ext: '.html',
+  dest: 'test/actual/multi/dest1/html-helpers.html',
+  assets: '../../assets',
+  src: 'test/fixtures/pages/html-helpers.hbs',
+  dirname: 'test/actual/multi/dest1',
   data: 
    { text: 'helpers.js',
      links: [ 'one', 'two', 'three', [length]: 3 ],
@@ -143,23 +154,12 @@
         { url: 'three', text: 'four' },
         { url: 'five', text: 'size' },
         [length]: 3 ] },
-  src: 'test/fixtures/pages/html-helpers.hbs',
-  assets: '../../assets',
-  _page: 'all',
   text: 'helpers.js',
-  dest: 'test/actual/multi/dest1/html-helpers.html',
-  pagename: 'html-helpers.html',
-  links: [ 'one', 'two', 'three', [length]: 3 ],
-  extname: '.html',
   pageName: 'html-helpers.html',
-  ext: '.html',
-  dirname: 'test/actual/multi/dest1',
   page: '\n{{#markdown}}\n\n## HTML list helpers.\n\n### \\{{ul}} helper\n{{#ul links class="nav"}}\n  {{.}}\n{{/ul}}\n\n{{#ul moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ul}}\n\n### \\{{ol}} helper\n{{#ol links class="nav"}}\n  {{.}}\n{{/ol}}\n\n{{#ol moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ol}}\n\n### \\{{link}} helper\n{{_link url text}}\n{{_link \'http://github.com\' \'GitHub\'}}\n{{_link \'http://github.com\' \'GitHub\' \'nav-link\'}}\n\n{{/markdown}}{{! /end markdown}}\n',
-  moreLinks: 
-   [ { url: 'one', text: 'two' },
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' },
-     [length]: 3 ] }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  basename: 'html-helpers',
+  filename: 'html-helpers.html' }
 </pre>
     </div>
 

--- a/test/actual/multi/dest1/html-helpers.md
+++ b/test/actual/multi/dest1/html-helpers.md
@@ -56,8 +56,19 @@
 
 ## Debug Info
 ``` json
-{ filename: 'html-helpers.md',
-  basename: 'html-helpers',
+{ _page: 'all',
+  pagename: 'html-helpers.md',
+  extname: '.md',
+  moreLinks: 
+   [ { url: 'one', text: 'two' },
+     { url: 'three', text: 'four' },
+     { url: 'five', text: 'size' },
+     [length]: 3 ],
+  ext: '.md',
+  dest: 'test/actual/multi/dest1/html-helpers.md',
+  assets: '../../assets',
+  src: 'test/fixtures/pages/html-helpers.hbs',
+  dirname: 'test/actual/multi/dest1',
   data: 
    { text: 'helpers.js',
      links: [ 'one', 'two', 'three', [length]: 3 ],
@@ -66,23 +77,12 @@
         { url: 'three', text: 'four' },
         { url: 'five', text: 'size' },
         [length]: 3 ] },
-  src: 'test/fixtures/pages/html-helpers.hbs',
-  assets: '../../assets',
-  _page: 'all',
   text: 'helpers.js',
-  dest: 'test/actual/multi/dest1/html-helpers.md',
-  pagename: 'html-helpers.md',
-  links: [ 'one', 'two', 'three', [length]: 3 ],
-  extname: '.md',
   pageName: 'html-helpers.md',
-  ext: '.md',
-  dirname: 'test/actual/multi/dest1',
   page: '\n{{#markdown}}\n\n## HTML list helpers.\n\n### \\{{ul}} helper\n{{#ul links class="nav"}}\n  {{.}}\n{{/ul}}\n\n{{#ul moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ul}}\n\n### \\{{ol}} helper\n{{#ol links class="nav"}}\n  {{.}}\n{{/ol}}\n\n{{#ol moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ol}}\n\n### \\{{link}} helper\n{{_link url text}}\n{{_link \'http://github.com\' \'GitHub\'}}\n{{_link \'http://github.com\' \'GitHub\' \'nav-link\'}}\n\n{{/markdown}}{{! /end markdown}}\n',
-  moreLinks: 
-   [ { url: 'one', text: 'two' },
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' },
-     [length]: 3 ] }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  basename: 'html-helpers',
+  filename: 'html-helpers.md' }
 ```
 
 

--- a/test/actual/multi/dest2/sub-dest/helpers.html
+++ b/test/actual/multi/dest2/sub-dest/helpers.html
@@ -35,16 +35,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1376517008510">
-<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1376517008510">
-<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1376517008510">
+<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1377971442621">
+<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1377971442621">
+<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1377971442621">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../../assets/js/js/bootstrap.js?v=1376517008510"></script>
-<script src="../../../assets/js/js/responsive.js?v=1376517008510"></script>
-<script src="../../../assets/js/js/main.js?v=1376517008510"></script>
+<script src="../../../assets/js/js/bootstrap.js?v=1377971442621"></script>
+<script src="../../../assets/js/js/responsive.js?v=1377971442621"></script>
+<script src="../../../assets/js/js/main.js?v=1377971442621"></script>
 
 
 <h2>custom variables</h2>
@@ -109,9 +109,26 @@ Example of using a custom "js" helper.
       <h2>Debug Info</h2>
       <pre class="json">
 [ 'test/helpers/helper-*.js',
+  _page: 'all',
+  pagename: 'helpers.html',
+  title: 'Helpers and custom variables',
   styles: '<link rel="stylesheet" href="css/index.css"/>',
-  filename: 'helpers.html',
-  basename: 'helpers',
+  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
+  ext: '.html',
+  extname: '.html',
+  dest: 'test/actual/multi/dest2/sub-dest/helpers.html',
+  assets: '../../../assets',
+  javascripts: [ 'js/bootstrap.js',
+    'js/responsive.js',
+    'js/main.js',
+    [length]: 3 ],
+  script: 'document.write(\'foo bar!\');',
+  stylesheets: [ 'css/bootstrap.css',
+    'css/responsive.css',
+    'css/main.css',
+    [length]: 3 ],
+  src: 'test/fixtures/pages/helpers.hbs',
+  dirname: 'test/actual/multi/dest2/sub-dest',
   data: { title: 'Helpers and custom variables',
     description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
     stylesheets: 
@@ -126,28 +143,11 @@ Example of using a custom "js" helper.
        [length]: 3 ],
     styles: '<link rel="stylesheet" href="css/index.css"/>',
     script: 'document.write(\'foo bar!\');' },
-  src: 'test/fixtures/pages/helpers.hbs',
-  assets: '../../../assets',
-  _page: 'all',
-  dest: 'test/actual/multi/dest2/sub-dest/helpers.html',
-  pagename: 'helpers.html',
-  title: 'Helpers and custom variables',
-  [length]: 1,
-  extname: '.html',
-  stylesheets: [ 'css/bootstrap.css',
-    'css/responsive.css',
-    'css/main.css',
-    [length]: 3 ],
-  script: 'document.write(\'foo bar!\');',
   pageName: 'helpers.html',
-  javascripts: [ 'js/bootstrap.js',
-    'js/responsive.js',
-    'js/main.js',
-    [length]: 3 ],
-  ext: '.html',
-  dirname: 'test/actual/multi/dest2/sub-dest',
   page: '\n<div class="page-header">\n  <h1>{{title}}</h1>\n  <p class="lead">{{description}}</p>\n</div>\n\n<h2>css helper</h2>\nExample of using a custom "css" helper.\n{{css stylesheets}}\n\n\n<h2>js helper</h2>\nExample of using a custom "js" helper.\n{{js javascripts}}\n\n\n<h2>custom variables</h2>\n{{{styles}}}\n<script>{{{script}}}</script>\n',
-  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n' ]
+  basename: 'helpers',
+  [length]: 1,
+  filename: 'helpers.html' ]
 </pre>
     </div>
 

--- a/test/actual/multi/dest2/sub-dest/html-helpers.html
+++ b/test/actual/multi/dest2/sub-dest/html-helpers.html
@@ -133,8 +133,19 @@
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ filename: 'html-helpers.html',
-  basename: 'html-helpers',
+{ _page: 'all',
+  pagename: 'html-helpers.html',
+  extname: '.html',
+  moreLinks: 
+   [ { url: 'one', text: 'two' },
+     { url: 'three', text: 'four' },
+     { url: 'five', text: 'size' },
+     [length]: 3 ],
+  ext: '.html',
+  dest: 'test/actual/multi/dest2/sub-dest/html-helpers.html',
+  assets: '../../../assets',
+  src: 'test/fixtures/pages/html-helpers.hbs',
+  dirname: 'test/actual/multi/dest2/sub-dest',
   data: 
    { text: 'helpers.js',
      links: [ 'one', 'two', 'three', [length]: 3 ],
@@ -143,23 +154,12 @@
         { url: 'three', text: 'four' },
         { url: 'five', text: 'size' },
         [length]: 3 ] },
-  src: 'test/fixtures/pages/html-helpers.hbs',
-  assets: '../../../assets',
-  _page: 'all',
   text: 'helpers.js',
-  dest: 'test/actual/multi/dest2/sub-dest/html-helpers.html',
-  pagename: 'html-helpers.html',
-  links: [ 'one', 'two', 'three', [length]: 3 ],
-  extname: '.html',
   pageName: 'html-helpers.html',
-  ext: '.html',
-  dirname: 'test/actual/multi/dest2/sub-dest',
   page: '\n{{#markdown}}\n\n## HTML list helpers.\n\n### \\{{ul}} helper\n{{#ul links class="nav"}}\n  {{.}}\n{{/ul}}\n\n{{#ul moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ul}}\n\n### \\{{ol}} helper\n{{#ol links class="nav"}}\n  {{.}}\n{{/ol}}\n\n{{#ol moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ol}}\n\n### \\{{link}} helper\n{{_link url text}}\n{{_link \'http://github.com\' \'GitHub\'}}\n{{_link \'http://github.com\' \'GitHub\' \'nav-link\'}}\n\n{{/markdown}}{{! /end markdown}}\n',
-  moreLinks: 
-   [ { url: 'one', text: 'two' },
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' },
-     [length]: 3 ] }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  basename: 'html-helpers',
+  filename: 'html-helpers.html' }
 </pre>
     </div>
 

--- a/test/actual/nested-layouts/helpers.html
+++ b/test/actual/nested-layouts/helpers.html
@@ -13,16 +13,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1376517008962">
-<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1376517008962">
-<link rel="stylesheet" href="../assets/css/css/main.css?v=1376517008962">
+<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1377971443012">
+<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1377971443012">
+<link rel="stylesheet" href="../assets/css/css/main.css?v=1377971443012">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../assets/js/js/bootstrap.js?v=1376517008962"></script>
-<script src="../assets/js/js/responsive.js?v=1376517008962"></script>
-<script src="../assets/js/js/main.js?v=1376517008962"></script>
+<script src="../assets/js/js/bootstrap.js?v=1377971443012"></script>
+<script src="../assets/js/js/responsive.js?v=1377971443012"></script>
+<script src="../assets/js/js/main.js?v=1377971443012"></script>
 
 
 <h2>custom variables</h2>

--- a/test/actual/paths/helpers.html
+++ b/test/actual/paths/helpers.html
@@ -16,16 +16,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1376517006927">
-<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1376517006927">
-<link rel="stylesheet" href="../assets/css/css/main.css?v=1376517006927">
+<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1377971441126">
+<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1377971441126">
+<link rel="stylesheet" href="../assets/css/css/main.css?v=1377971441126">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../assets/js/js/bootstrap.js?v=1376517006927"></script>
-<script src="../assets/js/js/responsive.js?v=1376517006927"></script>
-<script src="../assets/js/js/main.js?v=1376517006927"></script>
+<script src="../assets/js/js/bootstrap.js?v=1377971441126"></script>
+<script src="../assets/js/js/responsive.js?v=1377971441126"></script>
+<script src="../assets/js/js/main.js?v=1377971441126"></script>
 
 
 <h2>custom variables</h2>
@@ -39,9 +39,26 @@ Example of using a custom "js" helper.
 
 <pre class="json">
 [ 'test/helpers/helper-*.js',
+  _page: 'all',
+  pagename: 'helpers.html',
+  title: 'Helpers and custom variables',
   styles: '<link rel="stylesheet" href="css/index.css"/>',
-  filename: 'helpers.html',
-  basename: 'helpers',
+  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
+  ext: '.html',
+  extname: '.html',
+  dest: 'test/actual/paths/helpers.html',
+  assets: '../assets',
+  javascripts: [ 'js/bootstrap.js',
+    'js/responsive.js',
+    'js/main.js',
+    [length]: 3 ],
+  script: 'document.write(\'foo bar!\');',
+  stylesheets: [ 'css/bootstrap.css',
+    'css/responsive.css',
+    'css/main.css',
+    [length]: 3 ],
+  src: 'test/fixtures/pages/helpers.hbs',
+  dirname: 'test/actual/paths',
   data: { title: 'Helpers and custom variables',
     description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n',
     stylesheets: 
@@ -56,28 +73,11 @@ Example of using a custom "js" helper.
        [length]: 3 ],
     styles: '<link rel="stylesheet" href="css/index.css"/>',
     script: 'document.write(\'foo bar!\');' },
-  src: 'test/fixtures/pages/helpers.hbs',
-  assets: '../assets',
-  _page: 'all',
-  dest: 'test/actual/paths/helpers.html',
-  pagename: 'helpers.html',
-  title: 'Helpers and custom variables',
-  [length]: 1,
-  extname: '.html',
-  stylesheets: [ 'css/bootstrap.css',
-    'css/responsive.css',
-    'css/main.css',
-    [length]: 3 ],
-  script: 'document.write(\'foo bar!\');',
   pageName: 'helpers.html',
-  javascripts: [ 'js/bootstrap.js',
-    'js/responsive.js',
-    'js/main.js',
-    [length]: 3 ],
-  ext: '.html',
-  dirname: 'test/actual/paths',
   page: '\n<div class="page-header">\n  <h1>{{title}}</h1>\n  <p class="lead">{{description}}</p>\n</div>\n\n<h2>css helper</h2>\nExample of using a custom "css" helper.\n{{css stylesheets}}\n\n\n<h2>js helper</h2>\nExample of using a custom "js" helper.\n{{js javascripts}}\n\n\n<h2>custom variables</h2>\n{{{styles}}}\n<script>{{{script}}}</script>\n',
-  description: 'Here we are using the "css" and "js" helpers to output the stylesheets and scripts that we want for this page. These are custom helpers that can found in the "./test/helpers" directory To show another approach (as well as the advantage of using helpers), we also demonstrate adding styles and scrips with custom variables.\r\n' ]
+  basename: 'helpers',
+  [length]: 1,
+  filename: 'helpers.html' ]
 </pre>
 
       <ul>

--- a/test/actual/paths/html-helpers.html
+++ b/test/actual/paths/html-helpers.html
@@ -63,8 +63,19 @@
       <h3>Paths Examples</h3>
 
 <pre class="json">
-{ filename: 'html-helpers.html',
-  basename: 'html-helpers',
+{ _page: 'all',
+  pagename: 'html-helpers.html',
+  extname: '.html',
+  moreLinks: 
+   [ { url: 'one', text: 'two' },
+     { url: 'three', text: 'four' },
+     { url: 'five', text: 'size' },
+     [length]: 3 ],
+  ext: '.html',
+  dest: 'test/actual/paths/html-helpers.html',
+  assets: '../assets',
+  src: 'test/fixtures/pages/html-helpers.hbs',
+  dirname: 'test/actual/paths',
   data: 
    { text: 'helpers.js',
      links: [ 'one', 'two', 'three', [length]: 3 ],
@@ -73,23 +84,12 @@
         { url: 'three', text: 'four' },
         { url: 'five', text: 'size' },
         [length]: 3 ] },
-  src: 'test/fixtures/pages/html-helpers.hbs',
-  assets: '../assets',
-  _page: 'all',
   text: 'helpers.js',
-  dest: 'test/actual/paths/html-helpers.html',
-  pagename: 'html-helpers.html',
-  links: [ 'one', 'two', 'three', [length]: 3 ],
-  extname: '.html',
   pageName: 'html-helpers.html',
-  ext: '.html',
-  dirname: 'test/actual/paths',
   page: '\n{{#markdown}}\n\n## HTML list helpers.\n\n### \\{{ul}} helper\n{{#ul links class="nav"}}\n  {{.}}\n{{/ul}}\n\n{{#ul moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ul}}\n\n### \\{{ol}} helper\n{{#ol links class="nav"}}\n  {{.}}\n{{/ol}}\n\n{{#ol moreLinks class="nav"}}\n  <a href="{{url}}">{{text}}</a>\n{{/ol}}\n\n### \\{{link}} helper\n{{_link url text}}\n{{_link \'http://github.com\' \'GitHub\'}}\n{{_link \'http://github.com\' \'GitHub\' \'nav-link\'}}\n\n{{/markdown}}{{! /end markdown}}\n',
-  moreLinks: 
-   [ { url: 'one', text: 'two' },
-     { url: 'three', text: 'four' },
-     { url: 'five', text: 'size' },
-     [length]: 3 ] }
+  links: [ 'one', 'two', 'three', [length]: 3 ],
+  basename: 'html-helpers',
+  filename: 'html-helpers.html' }
 </pre>
 
       <ul>

--- a/test/actual/yfm/associative-arrays.html
+++ b/test/actual/yfm/associative-arrays.html
@@ -54,25 +54,25 @@
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ filename: 'associative-arrays.html',
-  basename: 'associative-arrays',
+{ _page: 'all',
   people: { name: 'John Smith', age: 33 },
+  pagename: 'associative-arrays.html',
+  title: 'Associative arrays',
+  extname: '.html',
+  ext: '.html',
+  dest: 'test/actual/yfm/associative-arrays.html',
+  assets: '../assets',
+  src: 'test/fixtures/pages/yfm/associative-arrays.hbs',
+  dirname: 'test/actual/yfm',
   data: 
    { title: 'Associative arrays',
      people: { name: 'John Smith', age: 33 },
      morePeople: { name: 'Grace Jones', age: 21 } },
-  src: 'test/fixtures/pages/yfm/associative-arrays.hbs',
-  assets: '../assets',
-  _page: 'all',
-  dest: 'test/actual/yfm/associative-arrays.html',
-  pagename: 'associative-arrays.html',
-  title: 'Associative arrays',
   morePeople: { name: 'Grace Jones', age: 21 },
-  extname: '.html',
   pageName: 'associative-arrays.html',
-  ext: '.html',
-  dirname: 'test/actual/yfm',
-  page: '\n<div class="page-header">\n  <h1>{{{title}}}</h1> \n</div>\n\n<div class="examples">\n  <h4>Associative arrays</h4>\n  <dl class="dl-horizontal">\n    {{#people}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/people}}\n    {{#morePeople}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/morePeople}}\n  </dl>\n</div>' }
+  page: '\n<div class="page-header">\n  <h1>{{{title}}}</h1> \n</div>\n\n<div class="examples">\n  <h4>Associative arrays</h4>\n  <dl class="dl-horizontal">\n    {{#people}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/people}}\n    {{#morePeople}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/morePeople}}\n  </dl>\n</div>',
+  basename: 'associative-arrays',
+  filename: 'associative-arrays.html' }
 </pre>
     </div>
 

--- a/test/actual/yfm/block-literals.html
+++ b/test/actual/yfm/block-literals.html
@@ -59,25 +59,25 @@ old pond . . . a frog leaps in water’s sound
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ poem: 'old pond . . .\r\na frog leaps in\r\nwater’s sound\r\n',
-  filename: 'block-literals.html',
-  basename: 'block-literals',
+{ _page: 'all',
+  pagename: 'block-literals.html',
+  title: 'Block Literals',
+  extname: '.html',
+  ext: '.html',
+  dest: 'test/actual/yfm/block-literals.html',
+  assets: '../assets',
+  src: 'test/fixtures/pages/yfm/block-literals.hbs',
+  dirname: 'test/actual/yfm',
+  another: 'old pond . . . a frog leaps in water’s sound\r\n',
   data: 
    { title: 'Block Literals',
      poem: 'old pond . . .\r\na frog leaps in\r\nwater’s sound\r\n',
      another: 'old pond . . . a frog leaps in water’s sound\r\n' },
-  src: 'test/fixtures/pages/yfm/block-literals.hbs',
-  assets: '../assets',
-  _page: 'all',
-  dest: 'test/actual/yfm/block-literals.html',
-  pagename: 'block-literals.html',
-  title: 'Block Literals',
-  extname: '.html',
+  poem: 'old pond . . .\r\na frog leaps in\r\nwater’s sound\r\n',
   pageName: 'block-literals.html',
-  ext: '.html',
-  dirname: 'test/actual/yfm',
   page: '\n<div class="page-header">\n  <h4>{{{title}}}</h4> \n</div>\n\n<h4>Newlines preserved</h4>\n<div class="almost-haiku">\n{{{poem}}}\n</div>\n\n<h4>Newlines folded</h4>\n<div class="another">\n{{{another}}}\n</div>\n\n\n\n\n',
-  another: 'old pond . . . a frog leaps in water’s sound\r\n' }
+  basename: 'block-literals',
+  filename: 'block-literals.html' }
 </pre>
     </div>
 

--- a/test/actual/yfm/document.html
+++ b/test/actual/yfm/document.html
@@ -139,13 +139,30 @@ Suite 16
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ customer: { given: 'Dorothy', family: 'Gale' },
-  filename: 'document.html',
+{ _page: 'all',
+  src: 'test/fixtures/pages/yfm/document.hbs',
   basename: 'document',
+  items: 
+   [ { part_no: 'A4786',
+       descrip: 'Water Bucket (Filled)',
+       price: 1.47,
+       quantity: 4 },
+     { part_no: 'E1628',
+       descrip: 'High Heeled "Ruby" Slippers',
+       size: 8,
+       price: 100.27,
+       quantity: 1 },
+     [length]: 2 ],
+  dirname: 'test/actual/yfm',
+  'bill-to': 
+   { street: '123 Tornado Alley\r\nSuite 16\r\n',
+     city: 'East Centerville',
+     state: 'KS' },
+  pagename: 'document.html',
   extname: '.html',
+  page: '\n<div class="page-header">\n  <h4>{{{title}}}</h4> \n</div>\n\n\n<!-- Customer Information\n============================================ -->\n<div class="customer-information">\n  <h4 style="background: #eee; display: block">Customer Information</h4>\n  <dl class="dl-horizontal">\n    <dt>Receipt:</dt>\n    <dd>{{receipt}}</dd>\n\n    <dt>Date:</dt>\n    <dd>{{prettyDate}}</dd>\n\n    <dt>First Name:</dt>\n    <dd>{{customer.given}}</dd>\n\n    <dt>Last Name:</dt>\n    <dd>{{customer.family}}</dd>\n  </dl>\n</div>\n\n<hr>\n\n<!-- Order Information\n============================================ -->\n<div class="customer-information">\n  <h4 style="background: #eee; display: block">Order Information</h4>\n  <dl class="dl-horizontal">\n    <dt>Items:</dt>\n    {{#each items}}\n    <dd>\n      <strong class="muted" style="border-bottom: 1px solid #ddd; display: block">Item #{{@index}}</strong>\n      <dl class="dl-horizontal">\n        <dt>Part No: </dt>\n        <dd> {{part_no}} </dd>\n        <dt>Description: </dt>\n        <dd> {{descrip}} </dd>\n        <dt>Price: </dt>\n        <dd> ${{price}} </dd>\n        <dt>Qty: </dt> \n        <dd> {{quantity}} </dd>\n      </dl>\n    </dd>\n    {{/each}}\n  </dl>\n</div>\n<hr>\n\n<!-- Bill To\n============================================ -->\n<div class="bill-to">\n  <h4 style="background: #eee; display: block">Address Information</h4>\n  <strong>Bill To:</strong>\n  <dl class="dl-horizontal">\n    <dt>Billing Street: </dt>\n    <dd> {{bill-to.street}} </dd>\n    <dt>Billing City: </dt>\n    <dd> {{bill-to.city}} </dd>\n    <dt>Billing State: </dt>\n    <dd> {{bill-to.state}} </dd>\n  </dl>\n  <strong>Ship To:</strong>\n  <dl class="dl-horizontal">\n    <dt>Shipping Street: </dt>\n    <dd> {{ship-to.street}} </dd>\n    <dt>Shipping City: </dt>\n    <dd> {{ship-to.city}} </dd>\n    <dt>Shipping State: </dt>\n    <dd> {{ship-to.state}} </dd>\n    </dd>\n  </dl>\n</div>\n\n<!-- Special Instructions\n============================================ -->\n<div class="special-instructions" style="margin-bottom: 120px;">\n  <h4 style="background: #eee; display: block">Delivery Instructions</h4>\n  <p>{{{specialDelivery}}}</p>\n</div>\n',
   data: 
-   { customer: { given: 'Dorothy', family: 'Gale' },
-     items: 
+   { items: 
       [ { part_no: 'A4786',
           descrip: 'Water Bucket (Filled)',
           price: 1.47,
@@ -160,46 +177,29 @@ Suite 16
       { street: '123 Tornado Alley\r\nSuite 16\r\n',
         city: 'East Centerville',
         state: 'KS' },
+     customer: { given: 'Dorothy', family: 'Gale' },
+     receipt: 'Oz-Ware Purchase Invoice',
+     specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\r\n',
+     date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
      'ship-to': 
       { street: '123 Tornado Alley\r\nSuite 16\r\n',
         city: 'East Centerville',
         state: 'KS' },
-     receipt: 'Oz-Ware Purchase Invoice',
-     date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
-     prettyDate: '2007-08-05',
-     specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\r\n' },
-  src: 'test/fixtures/pages/yfm/document.hbs',
-  items: 
-   [ { part_no: 'A4786',
-       descrip: 'Water Bucket (Filled)',
-       price: 1.47,
-       quantity: 4 },
-     { part_no: 'E1628',
-       descrip: 'High Heeled "Ruby" Slippers',
-       size: 8,
-       price: 100.27,
-       quantity: 1 },
-     [length]: 2 ],
-  'bill-to': 
-   { street: '123 Tornado Alley\r\nSuite 16\r\n',
-     city: 'East Centerville',
-     state: 'KS' },
+     prettyDate: '2007-08-05' },
+  ext: '.html',
+  customer: { given: 'Dorothy', family: 'Gale' },
+  dest: 'test/actual/yfm/document.html',
+  assets: '../assets',
+  receipt: 'Oz-Ware Purchase Invoice',
+  specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\r\n',
+  pageName: 'document.html',
+  date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
   'ship-to': 
    { street: '123 Tornado Alley\r\nSuite 16\r\n',
      city: 'East Centerville',
      state: 'KS' },
-  _page: 'all',
-  assets: '../assets',
-  pageName: 'document.html',
-  ext: '.html',
-  dirname: 'test/actual/yfm',
-  page: '\n<div class="page-header">\n  <h4>{{{title}}}</h4> \n</div>\n\n\n<!-- Customer Information\n============================================ -->\n<div class="customer-information">\n  <h4 style="background: #eee; display: block">Customer Information</h4>\n  <dl class="dl-horizontal">\n    <dt>Receipt:</dt>\n    <dd>{{receipt}}</dd>\n\n    <dt>Date:</dt>\n    <dd>{{prettyDate}}</dd>\n\n    <dt>First Name:</dt>\n    <dd>{{customer.given}}</dd>\n\n    <dt>Last Name:</dt>\n    <dd>{{customer.family}}</dd>\n  </dl>\n</div>\n\n<hr>\n\n<!-- Order Information\n============================================ -->\n<div class="customer-information">\n  <h4 style="background: #eee; display: block">Order Information</h4>\n  <dl class="dl-horizontal">\n    <dt>Items:</dt>\n    {{#each items}}\n    <dd>\n      <strong class="muted" style="border-bottom: 1px solid #ddd; display: block">Item #{{@index}}</strong>\n      <dl class="dl-horizontal">\n        <dt>Part No: </dt>\n        <dd> {{part_no}} </dd>\n        <dt>Description: </dt>\n        <dd> {{descrip}} </dd>\n        <dt>Price: </dt>\n        <dd> ${{price}} </dd>\n        <dt>Qty: </dt> \n        <dd> {{quantity}} </dd>\n      </dl>\n    </dd>\n    {{/each}}\n  </dl>\n</div>\n<hr>\n\n<!-- Bill To\n============================================ -->\n<div class="bill-to">\n  <h4 style="background: #eee; display: block">Address Information</h4>\n  <strong>Bill To:</strong>\n  <dl class="dl-horizontal">\n    <dt>Billing Street: </dt>\n    <dd> {{bill-to.street}} </dd>\n    <dt>Billing City: </dt>\n    <dd> {{bill-to.city}} </dd>\n    <dt>Billing State: </dt>\n    <dd> {{bill-to.state}} </dd>\n  </dl>\n  <strong>Ship To:</strong>\n  <dl class="dl-horizontal">\n    <dt>Shipping Street: </dt>\n    <dd> {{ship-to.street}} </dd>\n    <dt>Shipping City: </dt>\n    <dd> {{ship-to.city}} </dd>\n    <dt>Shipping State: </dt>\n    <dd> {{ship-to.state}} </dd>\n    </dd>\n  </dl>\n</div>\n\n<!-- Special Instructions\n============================================ -->\n<div class="special-instructions" style="margin-bottom: 120px;">\n  <h4 style="background: #eee; display: block">Delivery Instructions</h4>\n  <p>{{{specialDelivery}}}</p>\n</div>\n',
-  dest: 'test/actual/yfm/document.html',
-  receipt: 'Oz-Ware Purchase Invoice',
-  date: Sun Aug 05 2007 20:00:00 GMT-0400 (Eastern Daylight Time),
-  prettyDate: '2007-08-05',
-  specialDelivery: 'Follow the Yellow Brick Road to the Emerald City. Pay no attention to the man behind the curtain.\r\n',
-  pagename: 'document.html' }
+  filename: 'document.html',
+  prettyDate: '2007-08-05' }
 </pre>
     </div>
 

--- a/test/actual/yfm/lists.html
+++ b/test/actual/yfm/lists.html
@@ -114,12 +114,24 @@
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ filename: 'lists.html',
-  basename: 'lists',
+{ _page: 'all',
+  page: '\n<div class="page-header">\n  <h1>{{{title}}}</h1> \n</div>\n\n<div class="attributes">\n  <h4>Attributes</h4>\n  <ul>\n  {{#each attributes}}<li>{{.}}</li>\n  {{/each}}\n  </ul>\n</div>\n\n<hr>\n\n<div class="methods">\n  <h4>Methods</h4>\n  <ul>\n  {{#each methods}}<li>{{.}}</li>\n  {{/each}}\n  </ul>\n</div>\n\n<hr>\n\n<div class="examples">\n  <h3>Lists</h3>\n  <h4>Movies</h4>\n  <dl class="dl-horizontal">\n    {{#each movies}}\n      <dt>Movie:</dt> <dd>{{.}}</dd>\n    {{/each}}\n  </dl>\n\n  <h4>Groceries</h4>\n  <dl class="dl-horizontal">\n    {{#each groceries}}\n      <dt>Item:</dt> <dd>{{.}}</dd>\n    {{/each}}\n  </dl>\n</div>\n\n<hr>\n\n<div class="examples">\n  <h3>Hierarchical combinations of elements</h3>\n  <h4>Lists of associative arrays</h4>\n  <dl class="dl-horizontal">\n    {{#each people}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/each}}\n  </dl>\n\n  <h4>Associative arrays of lists</h4>\n  <dl class="dl-horizontal">\n    <div><strong>Men</strong></div>\n    {{#each men}}<dt>Name:</dt> <dd>{{.}}</dd>{{/each}}\n    <div><strong>Women</strong></div>\n    {{#each women}}<dt>Name:</dt> <dd>{{.}}</dd>{{/each}}\n  </dl>\n</div>',
   people: 
    [ { name: 'John Smith', age: 33 },
      { name: 'Mary Smith', age: 27 },
      [length]: 2 ],
+  pagename: 'lists.html',
+  title: 'Almost a Haiku',
+  extname: '.html',
+  ext: '.html',
+  dest: 'test/actual/yfm/lists.html',
+  assets: '../assets',
+  women: [ 'Mary Smith', 'Susan Williams', [length]: 2 ],
+  groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice', [length]: 4 ],
+  men: [ 'John Smith', 'Bill Jones', [length]: 2 ],
+  src: 'test/fixtures/pages/yfm/lists.hbs',
+  dirname: 'test/actual/yfm',
+  attributes: [ 'attr1', 'attr2', 'attr3', [length]: 3 ],
   data: 
    { title: 'Almost a Haiku',
      attributes: [ 'attr1', 'attr2', 'attr3', [length]: 3 ],
@@ -136,27 +148,15 @@
         [length]: 2 ],
      men: [ 'John Smith', 'Bill Jones', [length]: 2 ],
      women: [ 'Mary Smith', 'Susan Williams', [length]: 2 ] },
-  src: 'test/fixtures/pages/yfm/lists.hbs',
-  assets: '../assets',
-  _page: 'all',
-  groceries: [ 'milk', 'pumpkin pie', 'eggs', 'juice', [length]: 4 ],
-  dest: 'test/actual/yfm/lists.html',
-  methods: [ 'getter', 'setter', [length]: 2 ],
-  pagename: 'lists.html',
-  attributes: [ 'attr1', 'attr2', 'attr3', [length]: 3 ],
-  title: 'Almost a Haiku',
-  extname: '.html',
-  women: [ 'Mary Smith', 'Susan Williams', [length]: 2 ],
-  pageName: 'lists.html',
-  ext: '.html',
-  dirname: 'test/actual/yfm',
-  page: '\n<div class="page-header">\n  <h1>{{{title}}}</h1> \n</div>\n\n<div class="attributes">\n  <h4>Attributes</h4>\n  <ul>\n  {{#each attributes}}<li>{{.}}</li>\n  {{/each}}\n  </ul>\n</div>\n\n<hr>\n\n<div class="methods">\n  <h4>Methods</h4>\n  <ul>\n  {{#each methods}}<li>{{.}}</li>\n  {{/each}}\n  </ul>\n</div>\n\n<hr>\n\n<div class="examples">\n  <h3>Lists</h3>\n  <h4>Movies</h4>\n  <dl class="dl-horizontal">\n    {{#each movies}}\n      <dt>Movie:</dt> <dd>{{.}}</dd>\n    {{/each}}\n  </dl>\n\n  <h4>Groceries</h4>\n  <dl class="dl-horizontal">\n    {{#each groceries}}\n      <dt>Item:</dt> <dd>{{.}}</dd>\n    {{/each}}\n  </dl>\n</div>\n\n<hr>\n\n<div class="examples">\n  <h3>Hierarchical combinations of elements</h3>\n  <h4>Lists of associative arrays</h4>\n  <dl class="dl-horizontal">\n    {{#each people}}\n      <dt>Name:</dt> <dd>{{name}}</dd>\n      <dt>Age:</dt>  <dd>{{age}}</dd>\n    {{/each}}\n  </dl>\n\n  <h4>Associative arrays of lists</h4>\n  <dl class="dl-horizontal">\n    <div><strong>Men</strong></div>\n    {{#each men}}<dt>Name:</dt> <dd>{{.}}</dd>{{/each}}\n    <div><strong>Women</strong></div>\n    {{#each women}}<dt>Name:</dt> <dd>{{.}}</dd>{{/each}}\n  </dl>\n</div>',
-  men: [ 'John Smith', 'Bill Jones', [length]: 2 ],
   movies: 
    [ 'Casablanca',
      'North by Northwest',
      'The Man Who Wasn\'t There',
-     [length]: 3 ] }
+     [length]: 3 ],
+  pageName: 'lists.html',
+  methods: [ 'getter', 'setter', [length]: 2 ],
+  basename: 'lists',
+  filename: 'lists.html' }
 </pre>
     </div>
 

--- a/test/actual/yfm/variables.html
+++ b/test/actual/yfm/variables.html
@@ -54,25 +54,25 @@ other_thing: *NAME</code></pre>
     <div class="container" style="display: none">
       <h2>Debug Info</h2>
       <pre class="json">
-{ filename: 'variables.html',
-  basename: 'variables',
+{ _page: 'all',
+  pagename: 'variables.html',
+  title: 'YAML Variables',
+  extname: '.html',
+  ext: '.html',
+  dest: 'test/actual/yfm/variables.html',
+  assets: '../assets',
+  src: 'test/fixtures/pages/yfm/variables.hbs',
+  dirname: 'test/actual/yfm',
+  two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
   one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
   data: 
    { title: 'YAML Variables',
      one: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!',
      two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!' },
-  src: 'test/fixtures/pages/yfm/variables.hbs',
-  assets: '../assets',
-  _page: 'all',
-  dest: 'test/actual/yfm/variables.html',
-  pagename: 'variables.html',
-  title: 'YAML Variables',
-  extname: '.html',
   pageName: 'variables.html',
-  ext: '.html',
-  dirname: 'test/actual/yfm',
   page: '\n<div class="page-header">\n  <h4>{{{title}}}</h4> \n</div>\n\n{{{two}}}\n\n{{#markdown}}\nThis would output the variable as literal text.\n``` yaml\nthree: But this doesn\'t work. *DOOWB \n```\nAnd this would throw an error:\n\n``` yaml\nthree: *DOOWB But this doesn\'t work. \n```\n\nYAML supports **variables**, or **repeated nodes**. The simplest explanation is that you define something as a variable by preceding it with "&NAME value" and you can refer to it with "*NAME" e.g.:\n\n``` yaml\n# YAML\nsome_thing: &NAME foobar\nother_thing: *NAME\n```\nParses to:\n``` json\n{"other_thing": "foobar", "some_thing": "foobar"}\n```\n{{/markdown}}',
-  two: 'This is an example YAML variable. Variables need to be the first thing in the line. If it shows up in the result, it worked!' }
+  basename: 'variables',
+  filename: 'variables.html' }
 </pre>
     </div>
 


### PR DESCRIPTION
Adding a function as the second parameter to string.replace
when injecting the body content into layouts.

Fixes #286 so $ can be used inside pages.
