### PR TITLE
Adding metadata as alias for data on options.pages objects

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,6 +169,20 @@ module.exports = function(grunt) {
           'test/actual/object-blog/': ['test/fixtures/pages/blog/index.hbs']
         }
       },
+      pages_metadata: {
+        options: {
+          engine: 'handlebars',
+          layout: 'post.hbs',
+          site: {
+            title: 'Another Blog with Meta',
+            author: 'Brian Woodward'
+          },
+          pages: '<%= config.pages.three %>'
+        },
+        files: {
+          'test/actual/metadata-blog/': ['test/fixtures/pages/blog/index.hbs']
+        }
+      },
       nested_layouts: {
         options: {layout: 'one.hbs'},
         files: {

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -293,7 +293,7 @@ module.exports = function(grunt) {
             page = removeHbsWhitespace(assemble, page);
 
             var pageInfo = assemble.data.readYFM(page, {fromFile: false});
-            pageContext = useFileInfo ? (fileInfo.data || {}) : pageInfo.context;
+            pageContext = useFileInfo ? (fileInfo.data || fileInfo.metadata || {}) : pageInfo.context;
 
             // // compile
             // assemble.engine.compile(pageInfo.content, null, function(err, tmpl) {

--- a/test/actual/metadata-blog/index.html
+++ b/test/actual/metadata-blog/index.html
@@ -1,0 +1,45 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Another Blog with Meta</title>
+    <link href="http://libs.github.io/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <meta name="author" content="Brian Woodward">
+  </head>
+  <body>
+  	
+    	
+  	
+    	
+    		<div>Sweet Blog Post #1</div>
+    		<div>
+    			
+    			<script src="https://gist.github.com/5898072.js"></script>
+    			
+    		</div>
+    	
+  	
+    	
+    		<div>Awesome Blog Post #2</div>
+    		<div>
+    			
+    			<script src="https://gist.github.com/5898077.js"></script>
+    			
+    			<script src="https://gist.github.com/5898078.js"></script>
+    			
+    		</div>
+    	
+  	
+    	
+    		<div>Super Sweet and Awesome Blog Post #3</div>
+    		<div>
+    			
+    			<script src="https://gist.github.com/5898072.js"></script>
+    			
+    		</div>
+    	
+  	
+    <script src="http://libs.github.io/bootstrap/css/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/test/actual/metadata-blog/meta-awesome-blog-post-2.html
+++ b/test/actual/metadata-blog/meta-awesome-blog-post-2.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Another Blog with Meta</title>
+    <link href="http://libs.github.io/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <meta name="author" content="Brian Woodward">
+  </head>
+  <body>
+    
+      <script src="https://gist.github.com/5898077.js"></script>
+    
+      <script src="https://gist.github.com/5898078.js"></script>
+    
+    <h1>Awesome Blog Post #2 | Another Blog with Meta</h1>
+ <div class="alert"><strong>ALERT!</strong> This is an alert message. ></div> The current version of Assemble is v0.4.4.
+    <script src="http://libs.github.io/bootstrap/css/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/test/actual/metadata-blog/meta-super-sweet-and-awesome-blog-post-3.html
+++ b/test/actual/metadata-blog/meta-super-sweet-and-awesome-blog-post-3.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Another Blog with Meta</title>
+    <link href="http://libs.github.io/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <meta name="author" content="Brian Woodward">
+  </head>
+  <body>
+    
+      <script src="https://gist.github.com/5898072.js"></script>
+    
+    
+    <script src="http://libs.github.io/bootstrap/css/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/test/actual/metadata-blog/meta-sweet-blog-post-1.html
+++ b/test/actual/metadata-blog/meta-sweet-blog-post-1.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Another Blog with Meta</title>
+    <link href="http://libs.github.io/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <meta name="author" content="Brian Woodward">
+  </head>
+  <body>
+    
+      <script src="https://gist.github.com/5898072.js"></script>
+    
+    This 'content' property is optional and would get passed into the `body` tag. But if you only need to pass the page"s metadata to the layout then the content property is unnecessary.
+    <script src="http://libs.github.io/bootstrap/css/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/test/actual/multi/dest1/helpers.html
+++ b/test/actual/multi/dest1/helpers.html
@@ -35,16 +35,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1377980467211">
-<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1377980467211">
-<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1377980467211">
+<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1378148774599">
+<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1378148774599">
+<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1378148774599">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../../assets/js/js/bootstrap.js?v=1377980467211"></script>
-<script src="../../../assets/js/js/responsive.js?v=1377980467211"></script>
-<script src="../../../assets/js/js/main.js?v=1377980467211"></script>
+<script src="../../../assets/js/js/bootstrap.js?v=1378148774599"></script>
+<script src="../../../assets/js/js/responsive.js?v=1378148774599"></script>
+<script src="../../../assets/js/js/main.js?v=1378148774599"></script>
 
 
 <h2>custom variables</h2>

--- a/test/actual/multi/dest1/helpers.md
+++ b/test/actual/multi/dest1/helpers.md
@@ -11,16 +11,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../assets/css/css/bootstrap.css?v=1377980466103">
-<link rel="stylesheet" href="../../assets/css/css/responsive.css?v=1377980466103">
-<link rel="stylesheet" href="../../assets/css/css/main.css?v=1377980466103">
+<link rel="stylesheet" href="../../assets/css/css/bootstrap.css?v=1378148774061">
+<link rel="stylesheet" href="../../assets/css/css/responsive.css?v=1378148774061">
+<link rel="stylesheet" href="../../assets/css/css/main.css?v=1378148774061">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../assets/js/js/bootstrap.js?v=1377980466103"></script>
-<script src="../../assets/js/js/responsive.js?v=1377980466103"></script>
-<script src="../../assets/js/js/main.js?v=1377980466103"></script>
+<script src="../../assets/js/js/bootstrap.js?v=1378148774061"></script>
+<script src="../../assets/js/js/responsive.js?v=1378148774061"></script>
+<script src="../../assets/js/js/main.js?v=1378148774061"></script>
 
 
 <h2>custom variables</h2>

--- a/test/actual/multi/dest2/sub-dest/helpers.html
+++ b/test/actual/multi/dest2/sub-dest/helpers.html
@@ -35,16 +35,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1377980467831">
-<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1377980467831">
-<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1377980467831">
+<link rel="stylesheet" href="../../../assets/css/css/bootstrap.css?v=1378148774987">
+<link rel="stylesheet" href="../../../assets/css/css/responsive.css?v=1378148774987">
+<link rel="stylesheet" href="../../../assets/css/css/main.css?v=1378148774987">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../../../assets/js/js/bootstrap.js?v=1377980467831"></script>
-<script src="../../../assets/js/js/responsive.js?v=1377980467831"></script>
-<script src="../../../assets/js/js/main.js?v=1377980467831"></script>
+<script src="../../../assets/js/js/bootstrap.js?v=1378148774987"></script>
+<script src="../../../assets/js/js/responsive.js?v=1378148774987"></script>
+<script src="../../../assets/js/js/main.js?v=1378148774987"></script>
 
 
 <h2>custom variables</h2>

--- a/test/actual/nested-layouts/helpers.html
+++ b/test/actual/nested-layouts/helpers.html
@@ -13,16 +13,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1377980468904">
-<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1377980468904">
-<link rel="stylesheet" href="../assets/css/css/main.css?v=1377980468904">
+<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1378148775440">
+<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1378148775440">
+<link rel="stylesheet" href="../assets/css/css/main.css?v=1378148775440">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../assets/js/js/bootstrap.js?v=1377980468904"></script>
-<script src="../assets/js/js/responsive.js?v=1377980468904"></script>
-<script src="../assets/js/js/main.js?v=1377980468904"></script>
+<script src="../assets/js/js/bootstrap.js?v=1378148775440"></script>
+<script src="../assets/js/js/responsive.js?v=1378148775440"></script>
+<script src="../assets/js/js/main.js?v=1378148775440"></script>
 
 
 <h2>custom variables</h2>

--- a/test/actual/paths/helpers.html
+++ b/test/actual/paths/helpers.html
@@ -16,16 +16,16 @@
 
 <h2>css helper</h2>
 Example of using a custom "css" helper.
-<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1377980464800">
-<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1377980464800">
-<link rel="stylesheet" href="../assets/css/css/main.css?v=1377980464800">
+<link rel="stylesheet" href="../assets/css/css/bootstrap.css?v=1378148773520">
+<link rel="stylesheet" href="../assets/css/css/responsive.css?v=1378148773520">
+<link rel="stylesheet" href="../assets/css/css/main.css?v=1378148773520">
 
 
 <h2>js helper</h2>
 Example of using a custom "js" helper.
-<script src="../assets/js/js/bootstrap.js?v=1377980464801"></script>
-<script src="../assets/js/js/responsive.js?v=1377980464801"></script>
-<script src="../assets/js/js/main.js?v=1377980464801"></script>
+<script src="../assets/js/js/bootstrap.js?v=1378148773520"></script>
+<script src="../assets/js/js/responsive.js?v=1378148773520"></script>
+<script src="../assets/js/js/main.js?v=1378148773520"></script>
 
 
 <h2>custom variables</h2>

--- a/test/fixtures/data/config.json
+++ b/test/fixtures/data/config.json
@@ -48,6 +48,29 @@
           "gists": ["5898072"]
         }
       }
+    },
+    "three": {
+      "meta-sweet-blog-post-1": {
+        "metadata": {
+          "title": "Sweet Blog Post #1",
+          "gists": ["5898072"]
+        },
+        "content": "This 'content' property is optional and would get passed into the `body` tag. But if you only need to pass the page\"s metadata to the layout then the content property is unnecessary."
+      },
+      "meta-awesome-blog-post-2": {
+        "data": {
+          "title": "Awesome Blog Post #2",
+          "subtitle": "",
+          "gists": ["5898077", "5898078"]
+        },
+        "content": "<h1>{{title}} | {{site.title}}</h1>\n {{> <%= component.one %> }} The current version of Assemble is v<%= pkg.version %>."
+      },
+      "meta-super-sweet-and-awesome-blog-post-3": {
+        "metadata": {
+          "title": "Super Sweet and Awesome Blog Post #3",
+          "gists": ["5898072"]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Allows using `metadata: {}` instead of `data: {}` when defining
a page in the `options.pages` object in the grunt config.

This closes #246
