### PR TITLE
add support for plugins

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -608,6 +608,9 @@ module.exports = function(grunt) {
           context: context
         }, next);
       }, function (err) {
+        if(err) {
+          callback(err);
+        }
         assemble.engine.render(page, context, function(err, content) {
           if(err) {
             callback(err);

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -90,6 +90,8 @@ module.exports = function(grunt) {
       assemble.options.initializeEngine(assemble.engine, assemble.options);
       assemble.options.registerFunctions(assemble.engine);
 
+      assemble.options.plugins = assemble.options.plugins || [];
+
       next(assemble);
     };
 
@@ -599,12 +601,20 @@ module.exports = function(grunt) {
       //assemble.options.registerPartial(assemble.engine, 'body', page);
       page = injectBody(layout.layout, page);
 
-      assemble.engine.render(page, context, function(err, content) {
-        if(err) {
-          callback(err);
-        }
-        page = content;
-        callback(null, page);
+      async.forEachSeries(assemble.options.plugins, function (plugin, next) {
+        plugin({
+          grunt: grunt,
+          assemble: assemble,
+          context: context
+        }, next);
+      }, function (err) {
+        assemble.engine.render(page, context, function(err, content) {
+          if(err) {
+            callback(err);
+          }
+          page = content;
+          callback(null, page);
+        });
       });
 
 

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -90,7 +90,22 @@ module.exports = function(grunt) {
       assemble.options.initializeEngine(assemble.engine, assemble.options);
       assemble.options.registerFunctions(assemble.engine);
 
+      var actualPlugins = [];
+      // save original plugins option
+      assemble.options._plugins = assemble.options.plugins;
       assemble.options.plugins = assemble.options.plugins || [];
+      assemble.options.plugins.forEach(function (plugin) {
+        if (_.isString(plugin)) {
+          var requiredPlugins = grunt.file.expand(plugin).map(function(plugin) {
+            return require(path.join(process.cwd(), plugin));
+          });
+          actualPlugins = actualPlugins.concat(requiredPlugins);
+        }
+        else {
+          actualPlugins.push(plugin);
+        }
+      });
+      assemble.options.plugins = actualPlugins;
 
       next(assemble);
     };


### PR DESCRIPTION
This introduces the ability to specify plugins (functions) that can be run before the rendering of each page.

While implemented to be very flexible, I have found it most useful to manipulate my data and to create subsets of the pages array.

If there is interest, I can explain further, as well as provide examples and documentation.
