### PR TITLE
fix plugin resolustion for devDependencies

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -30,7 +30,7 @@ plugins.resolve = function (_plugins, options) {
     // if plugin is a string, attempt to resolve to module
     if (_.isString(plugin)) {
 
-      var resolved = resolve.load(plugin);
+      var resolved = resolve.all(plugin);
       // if resolved to an npm module then use it, otherwise assume local file/pattern so expand
       var relPaths = resolved.length ? resolved : grunt.file.expand(plugin);
 


### PR DESCRIPTION
Apparently `resolve.load` only considers `dependencies` but ignores `devDependencies`.
