### PR TITLE
Allow data config option to also accept an object of data

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -85,8 +85,11 @@ module.exports = function(grunt) {
       assemble.options.registerPartial = assemble.options.registerPartial || registerPartial;
 
       assemble.partials = file.expand(assemble.options.partials);
-      assemble.dataFiles = file.expand(assemble.options.data);
-      assemble.options.data = {};
+
+      if(_.isArray(assemble.options.data)) {
+        assemble.dataFiles = file.expand(assemble.options.data);
+        assemble.options.data = {};
+      }
 
       assemble.options.initializeEngine(assemble.engine, assemble.options);
       assemble.options.registerFunctions(assemble.engine);


### PR DESCRIPTION
This pull request allow the data option to accept a raw object of data addressing #364.

Call me crazy but it looks like this is all that's required.
I couldn't find the appropriate end-to-end test for the private `assembleData` method.

/ping @doowb @jonschlinkert
