### PR TITLE
Fixing default plugin path.

### DIFF
--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -58,7 +58,7 @@ var Assemble = function() {
     }
 
     // add default plugins
-    this.options.plugins = _.union(this.options.plugins, ['./lib/plugins/**/*.js']);
+    this.options.plugins = _.union(this.options.plugins, [path.relative(process.cwd(), path.join(__dirname, 'plugins'))+'/**/*.js']);
     
     // save original plugins option
     this.options._plugins = this.options.plugins;


### PR DESCRIPTION
When running assemble from another project, the default plugin
path was being calculated incorrectly.
