### PR TITLE
Making helpers work like plugins.

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -56,7 +56,7 @@ var EngineFactory = function() {
     return this;
   };
 
-  var init = function(options) {
+  var init = function(options, params) {
     if(functionExists(this.engine.init)) {
       this.engine.init(options);
     }
@@ -66,7 +66,7 @@ var EngineFactory = function() {
       }
       var engineEngine = this.engine[engineName] || this.engine;
       options.helpers.forEach(function(file) {
-        helpers.register(file, this.engine, engineEngine, options);
+        helpers.register(file, this.engine, engineEngine, options, params);
       }, this);
     }
   };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,7 +17,7 @@ var grunt   = require('grunt');
 var _       = grunt.util._;
 
 
-module.exports.register = function(patterns, plugin, engine, options) {
+module.exports.register = function(patterns, plugin, engine, options, params) {
 
   // Resolve and load helpers from node_modules, if the helper name is listed both
   // in the "helpers" option of the assemble task and devDependencies.
@@ -33,9 +33,9 @@ module.exports.register = function(patterns, plugin, engine, options) {
       helper = require(path.normalize(path.join(options.cwd || process.cwd() || '', file)));
       if(typeof helper !== 'undefined') {
         if(typeof helper.register !== 'undefined') {
-          helper.register(engine, options);
+          helper.register(engine, options, params);
         } else {
-          plugin.registerFunctions(helper, options);
+          plugin.registerFunctions(helper, options, params);
         }
       }
     } catch (ex) {

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -75,7 +75,7 @@ module.exports = function(grunt) {
 
       assemble.engine.load(assemble.options.engine);
 
-      var initializeEngine = function(engine, options) { engine.init(options); };
+      var initializeEngine = function(engine, options) { engine.init(options, { grunt: grunt, assemble: assemble }); };
       assemble.options.initializeEngine = assemble.options.initializeEngine || initializeEngine;
 
       var registerFunctions = function(engine) { engine.registerFunctions(); };


### PR DESCRIPTION
Adding a params object to the call to a helper.register so we can
pass in grunt and assemble and they can be used from inside helpers.

New helper signature is

``` js
module.exports.register = function(Handlebars, options, params) {
  Handlebars.register('awesome', function() {
    return params.assemble.options.foo;
  };
};
```
