### PR TITLE
Use grunt-release to automate releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -306,6 +306,24 @@ module.exports = function(grunt) {
     clean: {
       tests: ['test/actual/**/*.{html,md}'],
       permalinks: ['test/actual/2013/**']
+    },
+
+    // Automated releases. Bumps packages.json, creates new tag,
+    // and publishes new release to npm.
+    release: {
+      options: {
+        bump: true,
+        file: 'package.json',
+        add: false,
+        commit: true,
+        tag: true,
+        push: true,
+        pushTags: true,
+        npm: true,
+        tagName: '<%= version %>',
+        commitMessage: 'Bump version to <%= version %>',
+        tagMessage: 'Bump version to <%= version %>'
+      }
     }
   });
 
@@ -315,6 +333,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-readme');
   grunt.loadNpmTasks('grunt-sync-pkg');
+  grunt.loadNpmTasks('grunt-release');
 
   // Load this plugin.
   grunt.loadTasks('tasks');

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "grunt-readme": "~0.1.1",
     "grunt-sync-pkg": "~0.1.0",
     "js-prettify": "~1.4.0",
-    "time-grunt": "~0.1.1"
+    "time-grunt": "~0.1.1",
+    "grunt-release": "0.6.0"
   },
   "keywords": [
     "blog generator",


### PR DESCRIPTION
This is what I was thinking to simply the current release process. A any future releases would go as follows:
- Ensure origin/master has all the changes for the upcoming release
- Ensure local/master is up to date with origin/master
- run `grunt release:(patch|minor|major)` to release patch, minor, or major releases respectively

Running the above command will do the following:
- Update the version string in `package.json`
- Commit the new `package.json` file
- Create and push a git tag for the new version
- Publish the new version to npm

For what it's work I use this in all my personal and work projects.
