### PR TITLE
fixing layout/page context issue from #424

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -549,17 +549,18 @@ module.exports = function(grunt) {
           context.layoutName = pageLayout.layoutName;
           data = _.extend({}, data, pageLayout.data);
 
-          // extend again
-          options.data = undefined;
-          options.pages = undefined;
-          options.layout = undefined;
-          options.collections = undefined;
-          context = _.extend({}, context, assemble.util.filterProperties(options), data, pageContext);
-          options.data = data;
-          options.pages = pages;
-          options.collections = collections;
         }
       }
+
+      // extend again
+      options.data = undefined;
+      options.pages = undefined;
+      options.layout = undefined;
+      options.collections = undefined;
+      context = _.extend({}, context, assemble.util.filterProperties(options), layout.data, data, pageContext);
+      options.data = data;
+      options.pages = pages;
+      options.collections = collections;
 
 
       // add omitted collections back to pageContext


### PR DESCRIPTION
This change moves the extending of the context to outside of the "page layout" if statement. It also adds the `layout.data` to the extension chain. This will be populated with either the `defaultLayout` context (usually defined in `options.layout`, or the context from the layout stack starting in the page yfm.
