### PR TITLE
a possible fix for the gulp-assemble partials problem

### DIFF
--- a/lib/middleware/partials.js
+++ b/lib/middleware/partials.js
@@ -19,7 +19,7 @@ module.exports = function(assemble, next) {
     var partials = {};
     _.map(assemble.partials, function (filepath) {
       var partial = Component.readFile(filepath, 'partial');
-      partial.name = file.basename(filepath);
+      partials[file.basename(filepath)] = partial;
     });
     assemble.engine.registerPartials(partials, next);
   } else {

--- a/lib/render.js
+++ b/lib/render.js
@@ -41,8 +41,8 @@ Engine.prototype.registerPartials = function (partials, done) {
       var partial = partials[key];
       utils.expandComponent(partial);
       logger.verbose('Registering Partial: ');
-      logger.verbose('\t', partial.name);
-      this.renderer.registerPartial(partial.name, partial.content, next);
+      logger.verbose('\t', key);
+      this.renderer.registerPartial(key, partial.content, next);
       logger.verbose('\tfinished.');
     }.bind(this),
     function (err) {


### PR DESCRIPTION
I am not sure about if this is the best solution, having a _map that is not really mapping anything feels dirty, but at least registerPartials will not receive an empty {} anymore…
