### PR TITLE
Fix: Travis-CI build now passing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: node_js
-
 node_js:
   - "0.8"
-
 before_install:
   - npm install -g grunt-cli
-
 install:
   - npm install
-
-before_script:
-  - grunt build


### PR DESCRIPTION
The Travis file was using `before_script` instead of the desired `before_install`.
It is now passing the Travis-CI build.
