### PR TITLE
Fix pages collection changes not being picked up by Assemble

### DIFF
--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -44,7 +44,7 @@ var Assemble = function() {
     this.options.collections = mergeOptionsArrays.apply(this, [task.target, 'collections']);
 
     // add default collections
-    this.options.collections = _.union(this.options.collections, ['tags', 'categories', { name: 'pages' }]);
+    this.options.collections = _.union(['tags', 'categories', { name: 'pages' }], this.options.collections);
 
     this.options.collections = collection.normalize(this.options.collections);
 


### PR DESCRIPTION
Declared collections should be union'ed after the default collections so they can override defaults.  This fixes the issue where the declared pages collection is being overridden by the default, so if we wanted to sort descending, it wouldn't work.
