### PR TITLE
Core plugin path fix

### DIFF
--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -62,7 +62,7 @@ var Assemble = function() {
 
     // add default plugins
     var corePlugins = path.relative(process.cwd(), path.join(__dirname, 'plugins/*.js'));
-    this.options.plugins = (this.options.plugins || []).concat([corePlugins]);
+    this.options.plugins = _.union(utils.arrayify(this.options.plugins || []), [corePlugins]);
 
     // save original plugins option
     this.options._plugins = this.options.plugins;


### PR DESCRIPTION
uses the process.cwd to get the relative path to the core plugins so resolve-dep can find the correct directory from inside other projects. fixes #532

@jonschlinkert (or anyone else on Windows) will you pull this down and test it in a project using assemble to make sure the paths are correct for Windows?
