### PR TITLE
grunt Getting Started was 404. Linked to correct URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ assemble: {
 ```
 
 [grunt]: http://gruntjs.com/
-[Getting Started]: https://github.com/gruntjs/grunt/blob/devel/docs/getting_started.md
+[Getting Started]: http://gruntjs.com/getting-started
 [package.json]: https://npmjs.org/doc/json.html
 
 


### PR DESCRIPTION
The link to the grunt Getting Started guide is no longer correct. The new link points to the guide on gruntjs.com.
