### PR TITLE
Fix sortby and sortorder options for collections

### DIFF
--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -45,9 +45,11 @@ var Assemble = function() {
     this.options.collections = mergeOptionsArrays.apply(this, [task.target, 'collections']);
 
     // add default collections
-    this.options.collections = _.union(['tags', 'categories', { name: 'pages' }], this.options.collections);
-    this.options.collections = collection.normalize(this.options.collections);
+    collection.ensureCollection(this.options.collections, 'tags');
+    collection.ensureCollection(this.options.collections, 'categories');
+    collection.ensureCollection(this.options.collections, 'pages');
 
+    this.options.collections = collection.normalize(this.options.collections);
 
     // if there is a pages property and it's an array, turn it into an object
     if(this.options.pages && Array.isArray(this.options.pages)) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -127,46 +127,53 @@ collection.sort = function(col) {
 
 };
 
+/**
+ * Ensures that a given named collection is present in the array of collections
+ * passed as the first argument
+ * @param  {Array} collections: List of collection objects
+ * @param  {string} name: Name of collection to ensure
+ */
+collection.ensureCollection =function (collections, name) {
+  'use strict';
+  var index = _.findIndex(collections, function (collection) { return collection.name === name; });
+  if (index === -1)
+  {
+    console.log('Push ', name);
+    collections.push({ name: name, items:[], sortby:'', sortorder:'ASC'});
+  }
+  else
+  {
+    var item = collections[index];
+
+    if (item.name === 'pages') {
+      item.inflection = '_page';
+      item.sortby = item.sortby || 'name';
+      item.items = [{
+        '_page': 'all',
+        pages: []
+      }];
+      item.sortorder = item.sortorder || 'ASC';
+    }
+    else
+    {
+      item.inflection = inflection.singularize(item.name);
+      item.sortby = item.sortby || '';
+      item.items = item.items || [];
+      item.sortorder = item.sortorder || 'ASC';
+    }
+  }
+}
 
 /**
- * Takes in a list of collection definitions and normalizes
- * them to a be all objects with smart defaults
- * @param  {Array} collections: List of collections as either strings or objects
- * @return {Array}             Return list of collections, all as objects
+ * Takes in a list of collection and turns them into a single object
+ * with properties according to the names of the collections
  */
 collection.normalize = function(collections) {
   'use strict';
 
   var rtn = {};
   collections.forEach(function(item) {
-
-    if(typeof item === 'string') {
-      if(rtn[item]) {
-        item = rtn[item];
-      } else {
-        item = {
-          name: item,
-          inflection: inflection.singularize(item),
-          sortorder: 'ASC',
-          sortby: '',
-          items: []
-        };
-      }
-    } else {
-      item.items = [];
-    }
-
-    if(item.name === 'pages') {
-      item.inflection = '_page';
-      item.sortby = (item.sortby || '') === '' ? 'name' : item.sortby;
-      item.items = [{
-        '_page': 'all',
-        pages: []
-      }];
-    }
-
     rtn[item.name] = item;
-
   });
   return rtn;
 };


### PR DESCRIPTION
Prior to this change it was not possible to set the sort order of a collection.

In the code it used to use `_union` to merge options passed in by the user and the default options for 'pages', 'tags' and 'categories'. Since `_union` doesn't compare by name this was not working. The mixture of strings and objects in collections before calling normalize was also slightly 'unusual'.

With this change you can now add something like this to options: 

    collections : [ {name: 'pages', sortby:'order', sortorder:'ASC' } ]` 

And thus sort your pages by a field called 'order' instead of 'name'.