### PR TITLE
Update to include assemble-handlebars v0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "grunt mochaTest"
   },
   "dependencies": {
-    "assemble-handlebars": "^0.2.3",
+    "assemble-handlebars": "^0.2.4",
     "async": "^0.9.0",
     "gray-matter": "^0.4.2",
     "inflection": "^1.3.6",


### PR DESCRIPTION
would require https://github.com/assemble/assemble-handlebars/pull/22