### PR TITLE
Added extra 'filepath' parameter to registerPartial

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -122,7 +122,7 @@ module.exports = function(grunt) {
           assemble.options.data[filename] = _.extend({}, parsedPartial.data || {}, assemble.options.data[filename] || {});
 
           // register the partial
-          assemble.options.registerPartial(assemble.engine, filename, parsedPartial.content);
+          assemble.options.registerPartial(assemble.engine, filename, parsedPartial.content, filepath);
         });
       }
 


### PR DESCRIPTION
Had the problem that my module names were at the containing folder level, rather than on the '.hbs' files themselves, therefore 'filename' argument wasn't enough when registering them as partials. For this reason, I found it useful to have access to the 'filepath' argument as well.