### PR TITLE
Fix `getFile` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ Assemble.prototype.getCollection = function(name) {
  */
 
 Assemble.prototype.getFile = function(file, id) {
-  if (typeof file === 'object' || !file.hasOwnProperty('id')) {
+  if (typeof file !== 'object' || !file.hasOwnProperty('id')) {
     throw new Error('Assemble.getFile expects file objects to have an `id` property.');
   }
   return this.getCollection(id)[file.id];


### PR DESCRIPTION
The condition lead to never evaluate the `hasOwnProperty` call.
So it really really seems there's been a mistake between `===` and `!==`

Cheers