### PR TITLE
Include Bin in Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "files": [
     "index.js",
     "lib/",
-    "cli/"
+    "bin/"
   ],
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "lib/"
+    "lib/",
+    "cli/"
   ],
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Without explicitly listing `bin` as part of the package files, NPM won't find the files to copy and fails to install Assemble.