### PR TITLE
Update base-method dependency to base. Fixes #808

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "ansi-red": "^0.1.1",
     "async": "^1.5.1",
-    "base-methods": "^0.6.2",
+    "base": "^0.6.3",
     "buffer-equal": "^1.0.0",
     "consolidate": "^0.13.1",
     "coveralls": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ansi-red": "^0.1.1",
     "array-sort": "^0.1.1",
     "async": "^1.5.2",
-    "base-methods": "^0.6.2",
+    "base": "^0.6.3",
     "buffer-equal": "^1.0.0",
     "consolidate": "^0.13.1",
     "coveralls": "^2.11.6",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,7 +3,7 @@
 require('mocha');
 require('should');
 var path = require('path');
-var Base = require('base-methods');
+var Base = require('base');
 var assert = require('assert');
 var consolidate = require('consolidate');
 var handlebars = require('engine-handlebars');


### PR DESCRIPTION
- Changed dependency name to base from base-methods
- Changes dependency version to ^0.6.3 from ^0.6.2