### PR TITLE
Required and used 'base-watch' plugin for watch task in browser-sync recipe

### DIFF
--- a/docs/src/content/recipes/browser-sync.md
+++ b/docs/src/content/recipes/browser-sync.md
@@ -27,12 +27,18 @@ var less = require('gulp-less');
 var assemble = require('assemble');
 var extname = require('gulp-extname');
 var browserSync = require('browser-sync').create();
+var watch = require('base-watch');
 
 /**
  * Create an instance of assemble
  */
 
 var app = assemble();
+
+/**
+* Load plugins
+*/
+app.use(watch());
 
 /**
  * Load helpers


### PR DESCRIPTION
Tried the _browser-sync_ example and received an error of `app.watch is not a function`. It appears that the the built-in watch functionality was recently removed. So I replaced it with @doowb 's base-watch module, which I've seen used in other places.