### PR TITLE
Fix markdown in details tags not rendered properly

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -18,18 +18,21 @@ _(Click the following sections to expand them)_
 
 <details>
 <summary>Table of contents</summary>
+
 <!-- toc -->
 </details>
 
 
 <details>
 <summary>What is Assemble?</summary>
+
 Assemble is a command line tool and developer framework for rapid prototyping, static site generation, and [much more](#what-can-i-do-with-assemble). 
 </details>
 
 
 <details>
 <summary>Who uses assemble?</summary>
+
 Assemble is used by thousands of developers and teams in more than 170 countries! Here are a few examples of sites built with assemble:
 
 - [Airbus Group](http://www.airbusgroup.com/int/en.html)
@@ -52,6 +55,7 @@ Is your website, blog or project built with assemble? Please [let us know about 
 
 <details>
 <summary>Why should I use assemble?</summary>
+
 * Expressive, functional API (the API is also stable)
 * You can use assemble with any web framework or CSS/HTML toolkit
 * Assemble can build static sites or hybrid static/dynamic sites 
@@ -85,6 +89,7 @@ Is your website, blog or project built with assemble? Please [let us know about 
 
 <details>
 <summary>Rapid development toolkit</summary>
+
 Assemble can be used standalone, but it's even more powerful when used alongside the following libraries: 
 
 - [generate][]: scaffold out new projects from the command line
@@ -97,6 +102,7 @@ Assemble can be used standalone, but it's even more powerful when used alongside
 
 <details>
 <summary>Features</summary>
+
 Here are just a few of the features assemble offers:
 
 * Intuitive CLI


### PR DESCRIPTION
Some of the collapsed sections in readme.md contain raw, single-line Markdown when viewed on Github. Empty lines need to be added after each `<summary>` tag in order for contained Markdown to be parsed correctly.