### PR TITLE
Resolve #950 "Contribution guide link is broken in the project's issue template"

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,7 +2,7 @@
 
 - [ ] Have you searched for existing issues (open and close) to see if the bug or feature request has already been reported?
 - [ ] If this is a bug report, are you running the latest version of Assemble? If not, please update to the latest version and verify that the issue still occurs before proceding.
-- [ ] Have you read the [Contributing Guide](contributing.md)?
+- [ ] Have you read the [Contributing Guide](https://github.com/assemble/assemble/blob/master/.github/contributing.md)?
 - [ ] Have you reviewed the project readme (you might find advice about creating new issues)?
 - [ ] Are you creating an issue in the correct repository? (For example, if your issue is related to [grunt-assemble][] or [handlebars-helpers][], you will want to create the issue in that project).
 


### PR DESCRIPTION
Fix #950 